### PR TITLE
Part 1 of Proxy Configuration Support: Refactoring logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <proton-j-version>0.31.0</proton-j-version>
         <junit-version>4.12</junit-version>
         <slf4j-version>1.8.0-alpha2</slf4j-version>
-        <mockito-version>1.10.19</mockito-version>
+        <mockito-version>2.10.0</mockito-version>
         <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
         <checkstyle.consoleOutput>true</checkstyle.consoleOutput>
         <checkstyle.failOnViolation>true</checkstyle.failOnViolation>

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyAuthenticationType.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyAuthenticationType.java
@@ -1,0 +1,19 @@
+package com.microsoft.azure.proton.transport.proxy;
+
+/**
+ * Supported methods of proxy authentication.
+ */
+public enum ProxyAuthenticationType {
+    /**
+     * Proxy requires no authentication. Service calls will fail if proxy demands authentication.
+     */
+    NONE,
+    /**
+     * Authenticates against proxy with basic authentication scheme.
+     */
+    BASIC,
+    /**
+     * Authenticates against proxy with digest access authentication.
+     */
+    DIGEST,
+}

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
@@ -28,8 +28,21 @@ public interface ProxyHandler {
         }
     }
 
+    /**
+     * Creates a CONNECT request to the provided {@code hostName} and adds {@code additionalHeaders} to the request.
+     *
+     * @param hostName Name of the host to connect to.
+     * @param additionalHeaders Optional. Additional headers to add to the request.
+     * @return A string representing the HTTP CONNECT request.
+     */
     String createProxyRequest(String hostName, Map<String, String> additionalHeaders);
 
+    /**
+     * Verifies that {@code buffer} contains a successful CONNECT response.
+     *
+     * @param buffer Buffer containing the HTTP response.
+     * @return Indicates if CONNECT response contained a success. If not, contains an error indicating why the call was
+     * not successful.
+     */
     ProxyResponseResult validateProxyResponse(ByteBuffer buffer);
-
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
@@ -31,8 +31,8 @@ public class BasicProxyChallengeProcessorImpl implements ProxyChallengeProcessor
         final String usernamePasswordPair = proxyUserName + ":" + proxyPassword;
 
         headers.put(
-                "Proxy-Authorization",
-                "Basic " + Base64.getEncoder().encodeToString(usernamePasswordPair.getBytes()));
+                Constants.PROXY_AUTHORIZATION,
+                String.join(" ", Constants.BASIC, Base64.getEncoder().encodeToString(usernamePasswordPair.getBytes())));
         return headers;
     }
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
@@ -20,7 +20,7 @@ public class BasicProxyChallengeProcessorImpl implements ProxyChallengeProcessor
     @Override
     public Map<String, String> getHeader() {
         PasswordAuthentication passwordAuthentication =
-                proxyAuthenticator.getPasswordAuthentication(Constants.BASIC, host);
+                proxyAuthenticator.getPasswordAuthentication(Constants.BASIC_LOWERCASE, host);
 
         if (!ProxyAuthenticator.isPasswordAuthenticationHasValues(passwordAuthentication)) {
             return null;

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
@@ -7,7 +7,6 @@ import java.util.*;
 
 public class BasicProxyChallengeProcessorImpl implements ProxyChallengeProcessor {
 
-    private final String BASIC = "basic";
     private final ProxyAuthenticator proxyAuthenticator;
     private final Map<String, String> headers;
     private String host;
@@ -20,9 +19,12 @@ public class BasicProxyChallengeProcessorImpl implements ProxyChallengeProcessor
 
     @Override
     public Map<String, String> getHeader() {
-        PasswordAuthentication passwordAuthentication = proxyAuthenticator.getPasswordAuthentication(BASIC, host);
-        if (!proxyAuthenticator.isPasswordAuthenticationHasValues(passwordAuthentication))
+        PasswordAuthentication passwordAuthentication =
+                proxyAuthenticator.getPasswordAuthentication(Constants.BASIC, host);
+
+        if (!ProxyAuthenticator.isPasswordAuthenticationHasValues(passwordAuthentication)) {
             return null;
+        }
 
         String proxyUserName = passwordAuthentication.getUserName();
         String proxyPassword = new String(passwordAuthentication.getPassword());

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
@@ -2,6 +2,8 @@ package com.microsoft.azure.proton.transport.proxy.impl;
 
 class Constants {
     static final String PROXY_AUTHENTICATE_HEADER = "Proxy-Authenticate:";
+    static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
+
     static final String DIGEST = "Digest";
     static final String BASIC = "Basic";
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
@@ -1,0 +1,7 @@
+package com.microsoft.azure.proton.transport.proxy.impl;
+
+class Constants {
+    static final String PROXY_AUTHENTICATE_HEADER = "Proxy-Authenticate:";
+    static final String DIGEST = "Digest";
+    static final String BASIC = "Basic";
+}

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
@@ -1,9 +1,13 @@
 package com.microsoft.azure.proton.transport.proxy.impl;
 
+import java.util.Locale;
+
 class Constants {
     static final String PROXY_AUTHENTICATE_HEADER = "Proxy-Authenticate:";
     static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
 
     static final String DIGEST = "Digest";
     static final String BASIC = "Basic";
+    static final String BASIC_LOWERCASE = Constants.BASIC.toLowerCase(Locale.ROOT);
+    static final String DIGEST_LOWERCASE = Constants.DIGEST.toLowerCase(Locale.ROOT);
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
@@ -3,7 +3,6 @@ package com.microsoft.azure.proton.transport.proxy.impl;
 import com.microsoft.azure.proton.transport.proxy.ProxyChallengeProcessor;
 
 import javax.xml.bind.DatatypeConverter;
-import java.io.UnsupportedEncodingException;
 import java.net.*;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -95,7 +94,7 @@ public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcesso
             }
 
             headers.put("Proxy-Authorization", digestValue);
-        } catch(NoSuchAlgorithmException | UnsupportedEncodingException ex) {
+        } catch(NoSuchAlgorithmException ex) {
             throw new RuntimeException(ex);
         }
     }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
@@ -38,7 +38,7 @@ public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcesso
             String line = responseScanner.nextLine();
             if (line.contains(PROXY_AUTH_DIGEST)) {
                 getChallengeQuestionHeaders(line, challengeQuestionValues);
-                computeDigestAuthHeader(challengeQuestionValues, host, proxyAuthenticator.getPasswordAuthentication(Constants.DIGEST, host));
+                computeDigestAuthHeader(challengeQuestionValues, host, proxyAuthenticator.getPasswordAuthentication(Constants.DIGEST_LOWERCASE, host));
                 break;
             }
         }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
@@ -93,7 +93,7 @@ public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcesso
                         proxyUserName, realm, nonce, uri, cnonce, nc, response, qop);
             }
 
-            headers.put("Proxy-Authorization", digestValue);
+            headers.put(Constants.PROXY_AUTHORIZATION, digestValue);
         } catch(NoSuchAlgorithmException ex) {
             throw new RuntimeException(ex);
         }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
@@ -11,6 +11,8 @@ import java.security.SecureRandom;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcessor {
 
     private static final String PROXY_AUTH_DIGEST = Constants.PROXY_AUTHENTICATE_HEADER + " " + Constants.DIGEST;
@@ -74,20 +76,20 @@ public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcesso
 
             MessageDigest md5 = MessageDigest.getInstance("md5");
             SecureRandom secureRandom = new SecureRandom();
-            String a1 = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s:%s", proxyUserName, realm, proxyPassword).getBytes("UTF-8"))).toLowerCase();
-            String a2 = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s", "CONNECT", uri).getBytes("UTF-8"))).toLowerCase();
+            String a1 = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s:%s", proxyUserName, realm, proxyPassword).getBytes(UTF_8))).toLowerCase();
+            String a2 = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s", "CONNECT", uri).getBytes(UTF_8))).toLowerCase();
 
             byte[] cnonceBytes = new byte[16];
             secureRandom.nextBytes(cnonceBytes);
             String cnonce = DatatypeConverter.printHexBinary(cnonceBytes).toLowerCase();
             String response;
             if (qop == null || qop.isEmpty()) {
-                response = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s:%s", a1, nonce, a2).getBytes("UTF-8"))).toLowerCase();
+                response = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s:%s", a1, nonce, a2).getBytes(UTF_8))).toLowerCase();
                 digestValue = String.format("Digest username=\"%s\",realm=\"%s\",nonce=\"%s\",uri=\"%s\",cnonce=\"%s\",response=\"%s\"",
                         proxyUserName, realm, nonce, uri, cnonce, response);
             } else {
                 int nc = nonceCounter.incrementAndGet();
-                response = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s:%08X:%s:%s:%s", a1, nonce, nc, cnonce, qop, a2).getBytes("UTF-8"))).toLowerCase();
+                response = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s:%08X:%s:%s:%s", a1, nonce, nc, cnonce, qop, a2).getBytes(UTF_8))).toLowerCase();
                 digestValue = String.format("Digest username=\"%s\",realm=\"%s\",nonce=\"%s\",uri=\"%s\",cnonce=\"%s\",nc=%08X,response=\"%s\",qop=\"%s\"",
                         proxyUserName, realm, nonce, uri, cnonce, nc, response, qop);
             }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
@@ -33,26 +33,25 @@ public class ProxyAuthenticator {
                 Authenticator.RequestorType.PROXY);
     }
 
-    public boolean isPasswordAuthenticationHasValues(PasswordAuthentication passwordAuthentication){
-        if (passwordAuthentication == null) return false;
-        String proxyUserName = passwordAuthentication.getUserName() != null
-                ? passwordAuthentication.getUserName()
-                : null ;
-        String proxyPassword = passwordAuthentication.getPassword() != null
-                ? new String(passwordAuthentication.getPassword())
-                : null;
-        if (isNullOrEmpty(proxyUserName) || isNullOrEmpty(proxyPassword))  return false;
-        return true;
+    static boolean isPasswordAuthenticationHasValues(PasswordAuthentication passwordAuthentication) {
+        if (passwordAuthentication == null) {
+            return false;
+        }
+
+        final String username = passwordAuthentication.getUserName();
+        final char[] password = passwordAuthentication.getPassword();
+
+        return !isNullOrEmpty(username) && password != null && password.length > 0;
     }
 
-    private boolean isProxyAddressLegal(final List<Proxy> proxies) {
+    private static boolean isProxyAddressLegal(final List<Proxy> proxies) {
         return proxies != null
                 && !proxies.isEmpty()
                 && proxies.get(0).address() != null
                 && proxies.get(0).address() instanceof InetSocketAddress;
     }
 
-    private boolean isNullOrEmpty(String string) {
+    private static boolean isNullOrEmpty(String string) {
         return (string == null || string.isEmpty());
     }
 

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
@@ -8,41 +8,22 @@ import java.util.Objects;
  * Responds to proxy challenge requests by providing authentication information.
  */
 class ProxyAuthenticator {
-    private final PasswordAuthentication passwordAuthentication;
+    private static final String PROMPT = "Event Hubs client web socket proxy support";
 
     /**
      * Creates an authenticator that authenticates using system-configured authenticator.
      */
     ProxyAuthenticator() {
-        this.passwordAuthentication = null;
     }
 
     /**
-     * Creates an authenticator that responses to authentication requests with the provided {@code passwordAuthentication}.
-     *
-     * @param passwordAuthentication Credentials for authentication challenge.
-     * @throws NullPointerException if {@code passwordAuthentication} is {@code null}.
-     */
-    ProxyAuthenticator(PasswordAuthentication passwordAuthentication) {
-        Objects.requireNonNull(passwordAuthentication);
-
-        this.passwordAuthentication = new PasswordAuthentication(passwordAuthentication.getUserName(), passwordAuthentication.getPassword());
-    }
-
-    /**
-     * Gets the credentials to use for proxy authentication given the {@code scheme} and {@code host}. If
-     * {@link ProxyAuthenticator#ProxyAuthenticator(PasswordAuthentication)} was used to construct this instance, it is always
-     * returned.
+     * Gets the credentials to use for proxy authentication given the {@code scheme} and {@code host}.
      *
      * @param scheme The authentication scheme for the proxy.
      * @param host The proxy's URL that is requesting authentication.
      * @return The username and password to authenticate against proxy with.
      */
     PasswordAuthentication getPasswordAuthentication(String scheme, String host) {
-        if (passwordAuthentication != null) {
-            return passwordAuthentication;
-        }
-
         ProxySelector proxySelector = ProxySelector.getDefault();
 
         URI uri;
@@ -64,7 +45,7 @@ class ProxyAuthenticator {
                 proxyAddr,
                 0,
                 proxyType == null ? "" : proxyType.name(),
-                "Event Hubs client websocket proxy support",
+                PROMPT,
                 scheme,
                 null,
                 Authenticator.RequestorType.PROXY);
@@ -91,5 +72,4 @@ class ProxyAuthenticator {
     private static boolean isNullOrEmpty(String string) {
         return (string == null || string.isEmpty());
     }
-
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
@@ -40,6 +40,9 @@ class ProxyAuthenticator {
             proxyAddr = ((InetSocketAddress)proxies.get(0).address()).getAddress();
             proxyType = proxies.get(0).type();
         }
+
+        // It appears to be fine to pass in a null value for proxyAddr and proxyType (which maps to "scheme" argument in
+        // the call to requestPasswordAuthentication).
         return Authenticator.requestPasswordAuthentication(
                 "",
                 proxyAddr,

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
@@ -28,7 +28,7 @@ class ProxyAuthenticator {
 
         URI uri;
         List<Proxy> proxies = null;
-        if (!isNullOrEmpty(host)) {
+        if (!StringUtils.isNullOrEmpty(host)) {
             uri = URI.create(host);
             proxies = proxySelector.select(uri);
         }
@@ -62,7 +62,7 @@ class ProxyAuthenticator {
         final String username = passwordAuthentication.getUserName();
         final char[] password = passwordAuthentication.getPassword();
 
-        return !isNullOrEmpty(username) && password != null && password.length > 0;
+        return !StringUtils.isNullOrEmpty(username) && password != null && password.length > 0;
     }
 
     private static boolean isProxyAddressLegal(final List<Proxy> proxies) {
@@ -70,9 +70,5 @@ class ProxyAuthenticator {
                 && !proxies.isEmpty()
                 && proxies.get(0).address() != null
                 && proxies.get(0).address() instanceof InetSocketAddress;
-    }
-
-    private static boolean isNullOrEmpty(String string) {
-        return (string == null || string.isEmpty());
     }
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
@@ -28,7 +28,7 @@ class ProxyAuthenticator {
 
         URI uri;
         List<Proxy> proxies = null;
-        if (host != null && !host.isEmpty()) {
+        if (!isNullOrEmpty(host)) {
             uri = URI.create(host);
             proxies = proxySelector.select(uri);
         }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
@@ -2,10 +2,47 @@ package com.microsoft.azure.proton.transport.proxy.impl;
 
 import java.net.*;
 import java.util.List;
+import java.util.Objects;
 
-public class ProxyAuthenticator {
+/**
+ * Responds to proxy challenge requests by providing authentication information.
+ */
+class ProxyAuthenticator {
+    private final PasswordAuthentication passwordAuthentication;
 
-    public PasswordAuthentication getPasswordAuthentication(String scheme, String host) {
+    /**
+     * Creates an authenticator that authenticates using system-configured authenticator.
+     */
+    ProxyAuthenticator() {
+        this.passwordAuthentication = null;
+    }
+
+    /**
+     * Creates an authenticator that responses to authentication requests with the provided {@code passwordAuthentication}.
+     *
+     * @param passwordAuthentication Credentials for authentication challenge.
+     * @throws NullPointerException if {@code passwordAuthentication} is {@code null}.
+     */
+    ProxyAuthenticator(PasswordAuthentication passwordAuthentication) {
+        Objects.requireNonNull(passwordAuthentication);
+
+        this.passwordAuthentication = new PasswordAuthentication(passwordAuthentication.getUserName(), passwordAuthentication.getPassword());
+    }
+
+    /**
+     * Gets the credentials to use for proxy authentication given the {@code scheme} and {@code host}. If
+     * {@link ProxyAuthenticator#ProxyAuthenticator(PasswordAuthentication)} was used to construct this instance, it is always
+     * returned.
+     *
+     * @param scheme The authentication scheme for the proxy.
+     * @param host The proxy's URL that is requesting authentication.
+     * @return The username and password to authenticate against proxy with.
+     */
+    PasswordAuthentication getPasswordAuthentication(String scheme, String host) {
+        if (passwordAuthentication != null) {
+            return passwordAuthentication;
+        }
+
         ProxySelector proxySelector = ProxySelector.getDefault();
 
         URI uri;

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
@@ -14,6 +14,9 @@ import java.util.Scanner;
 
 public class ProxyHandlerImpl implements ProxyHandler {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String createProxyRequest(String hostName, Map<String, String> additionalHeaders) {
         final String endOfLine = "\r\n";
@@ -35,6 +38,9 @@ public class ProxyHandlerImpl implements ProxyHandler {
         return connectRequestBuilder.toString();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public ProxyResponseResult validateProxyResponse(ByteBuffer buffer) {
         int size = buffer.remaining();

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -259,12 +259,6 @@ public class ProxyImpl implements Proxy, TransportLayer {
                             return outputBuffer.position();
                         }
                     case PN_PROXY_CHALLENGE_RESPONDED:
-                        if (headClosed && (outputBuffer.position() == 0)) {
-                            proxyState = ProxyState.PN_PROXY_FAILED;
-                            return Transport.END_OF_STREAM;
-                        } else {
-                            return outputBuffer.position();
-                        }
                     case PN_PROXY_CONNECTING:
                         if (headClosed && (outputBuffer.position() == 0)) {
                             proxyState = ProxyState.PN_PROXY_FAILED;

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -5,18 +5,10 @@
 
 package com.microsoft.azure.proton.transport.proxy.impl;
 
-import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newWriteableBuffer;
-
 import com.microsoft.azure.proton.transport.proxy.Proxy;
 import com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType;
 import com.microsoft.azure.proton.transport.proxy.ProxyChallengeProcessor;
 import com.microsoft.azure.proton.transport.proxy.ProxyHandler;
-
-import java.nio.ByteBuffer;
-
-import java.util.Locale;
-import java.util.Map;
-
 import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.engine.TransportException;
 import org.apache.qpid.proton.engine.impl.TransportImpl;
@@ -24,11 +16,14 @@ import org.apache.qpid.proton.engine.impl.TransportInput;
 import org.apache.qpid.proton.engine.impl.TransportLayer;
 import org.apache.qpid.proton.engine.impl.TransportOutput;
 import org.apache.qpid.proton.engine.impl.TransportWrapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newWriteableBuffer;
 
 public class ProxyImpl implements Proxy, TransportLayer {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyImpl.class);
     private static final String PROXY_CONNECT_FAILED = "Proxy connect request failed with error: ";
     private static final int PROXY_HANDSHAKE_BUFFER_SIZE = 8 * 1024; // buffers used only for proxy-handshake
 

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -276,7 +276,6 @@ public class ProxyImpl implements Proxy, TransportLayer {
             if (getIsHandshakeInProgress()) {
                 switch (proxyState) {
                     case PN_PROXY_CONNECTING:
-                        return head;
                     case PN_PROXY_CHALLENGE_RESPONDED:
                         return head;
                     default:
@@ -292,16 +291,6 @@ public class ProxyImpl implements Proxy, TransportLayer {
             if (getIsHandshakeInProgress()) {
                 switch (proxyState) {
                     case PN_PROXY_CONNECTING:
-                        if (outputBuffer.position() != 0) {
-                            outputBuffer.flip();
-                            outputBuffer.position(bytes);
-                            outputBuffer.compact();
-                            head.position(0);
-                            head.limit(outputBuffer.position());
-                        } else {
-                            underlyingOutput.pop(bytes);
-                        }
-                        break;
                     case PN_PROXY_CHALLENGE_RESPONDED:
                         if (outputBuffer.position() != 0) {
                             outputBuffer.flip();

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -38,9 +38,9 @@ public class ProxyImpl implements Proxy, TransportLayer {
 
     private ProxyHandler proxyHandler;
 
-    private final String PROXY_AUTH_DIGEST = "Proxy-Authenticate: Digest";
-    private final String PROXY_AUTH_BASIC = "Proxy-Authenticate: Basic";
-    private final AtomicInteger nonceCounter = new AtomicInteger(0);
+    private static final String PROXY_AUTH_DIGEST = "Proxy-Authenticate: Digest";
+    private static final String PROXY_AUTH_BASIC = "Proxy-Authenticate: Basic";
+
     /**
      * Create proxy transport layer - which, after configuring using
      * the {@link #configure(String, Map, ProxyHandler, Transport)} API

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/StringUtils.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/StringUtils.java
@@ -1,0 +1,7 @@
+package com.microsoft.azure.proton.transport.proxy.impl;
+
+class StringUtils {
+    static boolean isNullOrEmpty(String string) {
+        return string == null || string.isEmpty();
+    }
+}

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImplTest.java
@@ -8,13 +8,12 @@ import java.net.*;
 import java.util.*;
 
 public class BasicProxyChallengeProcessorImplTest {
-
-    private final String headerKey = "Proxy-Authorization";
+    private static final String headerKey = "Proxy-Authorization";
+    private static final String HOSTNAME = "127.0.0.1";
+    private static final int PORT = 3128;
+    private static final String USERNAME = "basicuser";
+    private static final String PASSWORD = "basicpw";
     private Map<String, String> headers = new HashMap<>();
-    private final String HOSTNAME = "127.0.0.1";
-    private final int PORT = 3128;
-    private final String USERNAME = "basicuser";
-    private final String PASSWORD = "basicpw";
 
     @Test
     public void testGetHeaderBasic() {
@@ -43,6 +42,6 @@ public class BasicProxyChallengeProcessorImplTest {
         final String host = "";
         final BasicProxyChallengeProcessorImpl proxyChallengeProcessor = new BasicProxyChallengeProcessorImpl(host);
         headers = proxyChallengeProcessor.getHeader();
-        Assert.assertTrue(headers.get(headerKey).equals("Basic YmFzaWN1c2VyOmJhc2ljcHc="));
+        Assert.assertEquals("Basic YmFzaWN1c2VyOmJhc2ljcHc=", headers.get(headerKey));
     }
 }


### PR DESCRIPTION
I didn't want the PRs to have too much code churn, which would make it hard to comprehend each change and if it was not breaking.
This PR does not add any additional functionality, but does a lot of clean-up that my original (larger branch) had.  The changes are:

1. Update to compile against JDK 8.
   * The library already uses some JDK 8 features and proton-j compiles against JDK 8
1. Update Mockito version for testing.
   * My proxy tests make use of `ArgumentCaptor<T>`, which is available in the newer versions of Mockito.
1. Update naming of static variables and make variables that are constants, `static final`.
1. Use StandardCharsets.UTF_8 instead of hard coded "UTF-8"
1. Splits logic in `ProxyImpl.ProxyTransportWrapper.process` to make it easier to understand which `ProxyChallengeProcessor` is being returned
   1. `ProxyAuthenticationType` is added to support this. It will also be reused in Proxy Configuration support.
1. Adding documentation.
1. Consolidate duplicate switch statements. (Intelli-J suggested this and it made it easier for me to read.)