### PR TITLE
Digest changes plus some

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
         <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
         <checkstyle.consoleOutput>true</checkstyle.consoleOutput>
         <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyConfiguration.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyConfiguration.java
@@ -1,11 +1,11 @@
 package com.microsoft.azure.proton.transport.proxy;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.PasswordAuthentication;
 import java.util.Arrays;
 import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ProxyConfiguration implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConfiguration.class);

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
@@ -1,5 +1,7 @@
 package com.microsoft.azure.proton.transport.proxy.impl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.microsoft.azure.proton.transport.proxy.ProxyChallengeProcessor;
 
 import java.net.PasswordAuthentication;
@@ -8,7 +10,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class BasicProxyChallengeProcessorImpl implements ProxyChallengeProcessor {
 

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
@@ -2,8 +2,11 @@ package com.microsoft.azure.proton.transport.proxy.impl;
 
 import com.microsoft.azure.proton.transport.proxy.ProxyChallengeProcessor;
 
-import java.net.*;
-import java.util.*;
+import java.net.PasswordAuthentication;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
@@ -6,6 +6,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.microsoft.azure.proton.transport.proxy.ProxyChallengeProcessor;
 
 import java.net.PasswordAuthentication;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -82,24 +83,29 @@ public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcesso
         String realm = challengeQuestionValues.get("realm");
         String qop = challengeQuestionValues.get("qop");
 
-        String a1 = convertToHexString(md5.digest(String.format("%s:%s:%s", proxyUserName, realm, proxyPassword).getBytes(UTF_8)));
-        String a2 = convertToHexString(md5.digest(String.format("%s:%s", Constants.CONNECT, uri).getBytes(UTF_8)));
+        String a1 = getHashValue(proxyUserName, realm, proxyPassword);
+        String a2 = getHashValue(Constants.CONNECT, uri);
 
         byte[] cnonceBytes = new byte[16];
         secureRandom.nextBytes(cnonceBytes);
         String cnonce = convertToHexString(cnonceBytes);
-        String response;
+
         if (qop == null || qop.isEmpty()) {
-            response = convertToHexString(md5.digest(String.format("%s:%s:%s", a1, nonce, a2).getBytes(UTF_8)));
+            String response = getHashValue(a1, nonce, a2);
             digestValue = String.format("Digest username=\"%s\",realm=\"%s\",nonce=\"%s\",uri=\"%s\",cnonce=\"%s\",response=\"%s\"",
                     proxyUserName, realm, nonce, uri, cnonce, response);
         } else {
             int nc = nonceCounter.incrementAndGet();
-            response = convertToHexString(md5.digest(String.format("%s:%s:%08X:%s:%s:%s", a1, nonce, nc, cnonce, qop, a2).getBytes(UTF_8)));
+            String response = getHashValue(a1, nonce, String.format("%08X", nc), cnonce, qop, a2);
             digestValue = String.format("Digest username=\"%s\",realm=\"%s\",nonce=\"%s\",uri=\"%s\",cnonce=\"%s\",nc=%08X,response=\"%s\",qop=\"%s\"",
                     proxyUserName, realm, nonce, uri, cnonce, nc, response, qop);
         }
 
         headers.put(Constants.PROXY_AUTHORIZATION, digestValue);
+    }
+
+    private String getHashValue(String... parameters) {
+        final String content = String.join(":", parameters);
+        return convertToHexString(md5.digest(content.getBytes(UTF_8)));
     }
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
@@ -2,7 +2,6 @@ package com.microsoft.azure.proton.transport.proxy.impl;
 
 import com.microsoft.azure.proton.transport.proxy.ProxyChallengeProcessor;
 
-import javax.xml.bind.DatatypeConverter;
 import java.net.PasswordAuthentication;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -13,6 +12,7 @@ import java.util.Objects;
 import java.util.Scanner;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.microsoft.azure.proton.transport.proxy.impl.DigestUtils.convertToHexString;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcessor {
@@ -80,20 +80,20 @@ public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcesso
 
             MessageDigest md5 = MessageDigest.getInstance(DEFAULT_ALGORITHM);
             SecureRandom secureRandom = new SecureRandom();
-            String a1 = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s:%s", proxyUserName, realm, proxyPassword).getBytes(UTF_8))).toLowerCase();
-            String a2 = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s", Constants.CONNECT, uri).getBytes(UTF_8))).toLowerCase();
+            String a1 = convertToHexString(md5.digest(String.format("%s:%s:%s", proxyUserName, realm, proxyPassword).getBytes(UTF_8)));
+            String a2 = convertToHexString(md5.digest(String.format("%s:%s", Constants.CONNECT, uri).getBytes(UTF_8)));
 
             byte[] cnonceBytes = new byte[16];
             secureRandom.nextBytes(cnonceBytes);
-            String cnonce = DatatypeConverter.printHexBinary(cnonceBytes).toLowerCase();
+            String cnonce = convertToHexString(cnonceBytes);
             String response;
             if (qop == null || qop.isEmpty()) {
-                response = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s:%s", a1, nonce, a2).getBytes(UTF_8))).toLowerCase();
+                response = convertToHexString(md5.digest(String.format("%s:%s:%s", a1, nonce, a2).getBytes(UTF_8)));
                 digestValue = String.format("Digest username=\"%s\",realm=\"%s\",nonce=\"%s\",uri=\"%s\",cnonce=\"%s\",response=\"%s\"",
                         proxyUserName, realm, nonce, uri, cnonce, response);
             } else {
                 int nc = nonceCounter.incrementAndGet();
-                response = DatatypeConverter.printHexBinary(md5.digest(String.format("%s:%s:%08X:%s:%s:%s", a1, nonce, nc, cnonce, qop, a2).getBytes(UTF_8))).toLowerCase();
+                response = convertToHexString(md5.digest(String.format("%s:%s:%08X:%s:%s:%s", a1, nonce, nc, cnonce, qop, a2).getBytes(UTF_8)));
                 digestValue = String.format("Digest username=\"%s\",realm=\"%s\",nonce=\"%s\",uri=\"%s\",cnonce=\"%s\",nc=%08X,response=\"%s\",qop=\"%s\"",
                         proxyUserName, realm, nonce, uri, cnonce, nc, response, qop);
             }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
@@ -1,5 +1,8 @@
 package com.microsoft.azure.proton.transport.proxy.impl;
 
+import static com.microsoft.azure.proton.transport.proxy.impl.DigestUtils.convertToHexString;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.microsoft.azure.proton.transport.proxy.ProxyChallengeProcessor;
 
 import java.net.PasswordAuthentication;
@@ -11,9 +14,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Scanner;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static com.microsoft.azure.proton.transport.proxy.impl.DigestUtils.convertToHexString;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcessor {
 

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestUtils.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestUtils.java
@@ -1,0 +1,21 @@
+package com.microsoft.azure.proton.transport.proxy.impl;
+
+class DigestUtils {
+    private final static char[] HEX_CHARACTERS = "0123456789abcdef".toCharArray();
+
+    /**
+     * Converts a byte array to its hex string representation.
+     * Taken from: https://stackoverflow.com/a/9855338
+     */
+    static String convertToHexString(byte[] bytes) {
+        final char[] hexChars = new char[bytes.length * 2];
+
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = HEX_CHARACTERS[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_CHARACTERS[v & 0x0F];
+        }
+
+        return new String(hexChars);
+    }
+}

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestUtils.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestUtils.java
@@ -5,7 +5,7 @@ class DigestUtils {
 
     /**
      * Converts a byte array to its hex string representation.
-     * Taken from: https://stackoverflow.com/a/9855338
+     * From: https://stackoverflow.com/a/9855338
      */
     static String convertToHexString(byte[] bytes) {
         final char[] hexChars = new char[bytes.length * 2];

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestUtils.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestUtils.java
@@ -1,7 +1,7 @@
 package com.microsoft.azure.proton.transport.proxy.impl;
 
 class DigestUtils {
-    private final static char[] HEX_CHARACTERS = "0123456789abcdef".toCharArray();
+    private static final char[] HEX_CHARACTERS = "0123456789abcdef".toCharArray();
 
     /**
      * Converts a byte array to its hex string representation.

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.proton.transport.proxy.ProxyChallengeProcessor;
 import com.microsoft.azure.proton.transport.proxy.ProxyConfiguration;
 import com.microsoft.azure.proton.transport.proxy.ProxyHandler;
 import java.nio.ByteBuffer;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
@@ -386,7 +387,11 @@ public class ProxyImpl implements Proxy, TransportLayer {
 
             switch (authentication) {
                 case DIGEST:
-                    return new DigestProxyChallengeProcessorImpl(host, challenge, authenticator);
+                    try {
+                        return new DigestProxyChallengeProcessorImpl(host, challenge, authenticator);
+                    } catch (NoSuchAlgorithmException e) {
+                        throw new RuntimeException("Unable to create DigestProxyChallengeProcessor.", e);
+                    }
                 case BASIC:
                     return new BasicProxyChallengeProcessorImpl(host, authenticator);
                 default:

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -5,11 +5,23 @@
 
 package com.microsoft.azure.proton.transport.proxy.impl;
 
+import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.BASIC;
+import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.DIGEST;
+import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newWriteableBuffer;
+
 import com.microsoft.azure.proton.transport.proxy.Proxy;
 import com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType;
 import com.microsoft.azure.proton.transport.proxy.ProxyChallengeProcessor;
 import com.microsoft.azure.proton.transport.proxy.ProxyConfiguration;
 import com.microsoft.azure.proton.transport.proxy.ProxyHandler;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.engine.TransportException;
 import org.apache.qpid.proton.engine.impl.TransportImpl;
@@ -19,19 +31,6 @@ import org.apache.qpid.proton.engine.impl.TransportOutput;
 import org.apache.qpid.proton.engine.impl.TransportWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Scanner;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.BASIC;
-import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.DIGEST;
-import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newWriteableBuffer;
 
 public class ProxyImpl implements Proxy, TransportLayer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyImpl.class);

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImplTest.java
@@ -22,12 +22,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.microsoft.azure.proton.transport.proxy.impl.DigestUtils.convertToHexString;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static javax.xml.bind.DatatypeConverter.printHexBinary;
 
 public class DigestProxyChallengeProcessorImplTest {
     private static final String NEW_LINE = "\r\n";
@@ -239,7 +238,7 @@ public class DigestProxyChallengeProcessorImplTest {
 
             String expectedRawResponse = String.join(":",
                     a1, expected.get(NONCE_KEY), expected.get(NC_KEY), actual.get(CNONCE_KEY), expected.get(QOP_KEY), a2);
-            String expectedResponse = printHexBinary(md5.digest(expectedRawResponse.getBytes(UTF_8))).toLowerCase(Locale.ROOT);
+            String expectedResponse = convertToHexString(md5.digest(expectedRawResponse.getBytes(UTF_8)));
 
             Assert.assertEquals(expectedResponse, actual.get(RESPONSE_KEY));
         }

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImplTest.java
@@ -77,7 +77,7 @@ public class DigestProxyChallengeProcessorImplTest {
     }
 
     @Test
-    public void testGetHeaderDigest() {
+    public void testGetHeaderDigest() throws NoSuchAlgorithmException {
         // Arrange
         final String realm = "Squid proxy-caching web server";
         final String nonce = "zWV5XAAAAAAgz1ACAAAAAE9hOwIAAAAA";
@@ -105,7 +105,7 @@ public class DigestProxyChallengeProcessorImplTest {
      * the system defined ones.
      */
     @Test
-    public void testGetHeaderDigestWithProxy() {
+    public void testGetHeaderDigestWithProxy() throws NoSuchAlgorithmException {
         // Arrange
         final String realm = "My Test Realm";
         final String nonce = "A randomly generated nonce";
@@ -139,7 +139,7 @@ public class DigestProxyChallengeProcessorImplTest {
      * Verifies that if we cannot obtain credentials from proxyAuthenticator, then we return null.
      */
     @Test
-    public void cannotObtainPasswordCredentialsWithValues() {
+    public void cannotObtainPasswordCredentialsWithValues() throws NoSuchAlgorithmException {
         Authenticator.setDefault(new Authenticator() {
             @Override
             protected PasswordAuthentication getPasswordAuthentication() {


### PR DESCRIPTION
Fixes:
* DataTypeConverter is removed in JDK 11. Removes this reliance in DIgestChallengeProcessor to future-proof it.
* Instantiates `MessageDigest` and `SecureRandom` because creating the message digest is a long process and creating the SecureRandom each time `getHeader` is called could result in the same seed.
* There was a warning about it being platform dependent because using CP1252 encoding. Changed to use UTF-8 source encoding
   * [Reference](https://maven.apache.org/general.html#encoding-warning)
* Fixes checkstyle issues
   * Rules export import statements to be alphabetically ordered with `static` imports first.
   * Expands `*` imports
* Cleaning up DigestChallengeProcessor with a `getHexValue` method.