### PR TITLE
Update package version, remove DatatypeConverter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,12 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>qpid-proton-j-extensions</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 
     <url>https://github.com/Azure/qpid-proton-j-extensions</url>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <proton-j-version>0.31.0</proton-j-version>
         <junit-version>4.12</junit-version>
         <slf4j-version>1.8.0-alpha2</slf4j-version>

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.BASIC;
 import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.DIGEST;
+import static com.microsoft.azure.proton.transport.proxy.impl.ProxyHandlerImpl.NEW_LINE;
 import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newWriteableBuffer;
 
 public class ProxyImpl implements Proxy, TransportLayer {
@@ -117,7 +118,12 @@ public class ProxyImpl implements Proxy, TransportLayer {
 
     protected void writeProxyRequest() {
         outputBuffer.clear();
-        String request = proxyHandler.createProxyRequest(host, headers);
+        final String request = proxyHandler.createProxyRequest(host, headers);
+
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Writing proxy request:{}{}", System.lineSeparator(), request);
+        }
+
         outputBuffer.put(request.getBytes());
     }
 

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImplTest.java
@@ -26,8 +26,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.microsoft.azure.proton.transport.proxy.impl.DigestProxyChallengeProcessorImpl.printHexBinary;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static javax.xml.bind.DatatypeConverter.printHexBinary;
 
 public class DigestProxyChallengeProcessorImplTest {
     private static final String NEW_LINE = "\r\n";


### PR DESCRIPTION
Fixes:
* DatatypeConverter is removed in JDK 11. Removes this reliance in DigestChallengeProcessor. Our tests in azure-sdk-for-java run against JDK 11.
* There was a warning about it being platform dependent because using CP1252 encoding. Changed to use UTF-8 source encoding
   * [Reference](https://maven.apache.org/general.html#encoding-warning)