### PR TITLE
Enable build failure on checkstyles, then fix checkstyle issues

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -207,9 +207,7 @@
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
-            <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="ParenPad"/>

--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,8 @@
         <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
 
-        <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
-        <checkstyle.consoleOutput>true</checkstyle.consoleOutput>
-        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
+        <!-- Build tools -->
+        <checkstyle.version>8.18</checkstyle.version>
     </properties>
 
     <build>
@@ -54,9 +53,19 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.18</version>
+                        <version>${checkstyle.version}</version>
                     </dependency>
                 </dependencies>
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <linkXRef>true</linkXRef>
+
+                    <failsOnError>true</failsOnError>
+                    <failOnViolation>true</failOnViolation>
+                    <violationSeverity>warning</violationSeverity>
+                </configuration>
             </plugin>
 
             <!-- Configure the jar plugin -->

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyConfiguration.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyConfiguration.java
@@ -29,19 +29,18 @@ public class ProxyConfiguration implements AutoCloseable {
     }
 
     /**
-     * Creates a proxy configuration that uses the {@code proxyAddress} and authenticates with provided
-     * {@code username}, {@code password} and {@code authentication}.
+     * Creates a proxy configuration that uses the {@code proxyAddress} and authenticates with provided {@code
+     * username}, {@code password} and {@code authentication}.
      *
      * @param authentication Authentication method to preemptively use with proxy.
-     * @param proxyAddress Proxy to use. If {@code null} is passed in, then the system configured {@link java.net.Proxy}
-     * is used.
+     * @param proxyAddress Proxy to use. If {@code null} is passed in, then the system configured {@link
+     *         java.net.Proxy} is used.
      * @param username Optional. Username used to authenticate with proxy. If not specified, the system-wide
-     * {@link java.net.Authenticator} is used to fetch credentials.
+     *         {@link java.net.Authenticator} is used to fetch credentials.
      * @param password Optional. Password used to authenticate with proxy.
-     *
      * @throws NullPointerException if {@code authentication} is {@code null}.
      * @throws IllegalArgumentException if {@code authentication} is {@link ProxyAuthenticationType#BASIC} or
-     * {@link ProxyAuthenticationType#DIGEST} and {@code username} or {@code password} are {@code null}.
+     *         {@link ProxyAuthenticationType#DIGEST} and {@code username} or {@code password} are {@code null}.
      */
     public ProxyConfiguration(ProxyAuthenticationType authentication, java.net.Proxy proxyAddress, String username, String password) {
         Objects.requireNonNull(authentication);
@@ -63,8 +62,8 @@ public class ProxyConfiguration implements AutoCloseable {
     /**
      * Gets the proxy address.
      *
-     * @return The proxy address. Returns {@code null} if user creates proxy credentials with
-     * {@link ProxyConfiguration#SYSTEM_DEFAULTS}.
+     * @return The proxy address. Returns {@code null} if user creates proxy credentials with {@link
+     *         ProxyConfiguration#SYSTEM_DEFAULTS}.
      */
     public java.net.Proxy proxyAddress() {
         return proxyAddress;
@@ -74,7 +73,7 @@ public class ProxyConfiguration implements AutoCloseable {
      * Gets credentials to authenticate against proxy with.
      *
      * @return The credentials to authenticate against proxy with. Returns {@code null} if no credentials were set. This
-     * occurs when user uses {@link ProxyConfiguration#SYSTEM_DEFAULTS}.
+     *         occurs when user uses {@link ProxyConfiguration#SYSTEM_DEFAULTS}.
      */
     public PasswordAuthentication credentials() {
         return credentials;
@@ -84,7 +83,7 @@ public class ProxyConfiguration implements AutoCloseable {
      * Gets the proxy authentication type to use.
      *
      * @return The proxy authentication type to use. returns {@code null} if no authentication type was set. This occurs
-     * when user uses {@link ProxyConfiguration#SYSTEM_DEFAULTS}.
+     *         when user uses {@link ProxyConfiguration#SYSTEM_DEFAULTS}.
      */
     public ProxyAuthenticationType authentication() {
         return authentication;

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
@@ -42,7 +42,7 @@ public interface ProxyHandler {
      *
      * @param buffer Buffer containing the HTTP response.
      * @return Indicates if CONNECT response contained a success. If not, contains an error indicating why the call was
-     * not successful.
+     *         not successful.
      */
     ProxyResponseResult validateProxyResponse(ByteBuffer buffer);
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/BasicProxyChallengeProcessorImpl.java
@@ -2,8 +2,11 @@ package com.microsoft.azure.proton.transport.proxy.impl;
 
 import com.microsoft.azure.proton.transport.proxy.ProxyChallengeProcessor;
 
-import java.net.*;
-import java.util.*;
+import java.net.PasswordAuthentication;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
@@ -56,7 +56,8 @@ public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcesso
 
             if (line.contains(PROXY_AUTH_DIGEST)) {
                 getChallengeQuestionHeaders(line, challengeQuestionValues);
-                computeDigestAuthHeader(challengeQuestionValues, host, proxyAuthenticator.getPasswordAuthentication(Constants.DIGEST_LOWERCASE, host));
+                computeDigestAuthHeader(challengeQuestionValues, host,
+                        proxyAuthenticator.getPasswordAuthentication(Constants.DIGEST_LOWERCASE, host));
 
                 logger.info("Finished getting auth header.");
                 break;
@@ -143,7 +144,8 @@ public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcesso
 
                 response = printHexBinary(md5.digest(String.format("%s:%s:%08X:%s:%s:%s", a1, nonce, nc, cnonce, qop, a2).getBytes(UTF_8)));
 
-                digestValue = String.format("Digest username=\"%s\",realm=\"%s\",nonce=\"%s\",uri=\"%s\",cnonce=\"%s\",nc=%08X,response=\"%s\",qop=\"%s\"",
+                digestValue = String.format(
+                        "Digest username=\"%s\",realm=\"%s\",nonce=\"%s\",uri=\"%s\",cnonce=\"%s\",nc=%08X,response=\"%s\",qop=\"%s\"",
                         proxyUserName, realm, nonce, uri, cnonce, nc, response, qop);
             }
 

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticator.java
@@ -29,7 +29,7 @@ class ProxyAuthenticator {
     }
 
     /**
-     * Creates an authenticator that responses to authentication requests with the provided
+     * Creates an authenticator that responses to authentication requests with the provided configuration.
      *
      * @param configuration Proxy configuration to use for requests.
      * @throws NullPointerException if {@code configuration} is {@code null}.

--- a/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketHandlerImpl.java
@@ -65,7 +65,7 @@ public class WebSocketHandlerImpl implements WebSocketHandler {
 
                 retVal = webSocketUpgrade.validateUpgradeReply(data);
                 if (retVal) {
-                	webSocketUpgrade = null;
+                    webSocketUpgrade = null;
                 }
             }
         }

--- a/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketImpl.java
@@ -5,18 +5,9 @@
 
 package com.microsoft.azure.proton.transport.ws.impl;
 
-import static com.microsoft.azure.proton.transport.ws.WebSocketHandler.WebSocketMessageType.WEB_SOCKET_MESSAGE_TYPE_HEADER_CHUNK;
-import static com.microsoft.azure.proton.transport.ws.WebSocketHandler.WebSocketMessageType.WEB_SOCKET_MESSAGE_TYPE_UNKNOWN;
-import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newWriteableBuffer;
-import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.pourAll;
-
 import com.microsoft.azure.proton.transport.ws.WebSocket;
 import com.microsoft.azure.proton.transport.ws.WebSocketHandler;
 import com.microsoft.azure.proton.transport.ws.WebSocketHeader;
-
-import java.nio.ByteBuffer;
-import java.util.Map;
-
 import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.engine.TransportException;
 import org.apache.qpid.proton.engine.impl.ByteBufferUtils;
@@ -25,14 +16,21 @@ import org.apache.qpid.proton.engine.impl.TransportInput;
 import org.apache.qpid.proton.engine.impl.TransportLayer;
 import org.apache.qpid.proton.engine.impl.TransportOutput;
 import org.apache.qpid.proton.engine.impl.TransportWrapper;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import static com.microsoft.azure.proton.transport.ws.WebSocketHandler.WebSocketMessageType.WEB_SOCKET_MESSAGE_TYPE_HEADER_CHUNK;
+import static com.microsoft.azure.proton.transport.ws.WebSocketHandler.WebSocketMessageType.WEB_SOCKET_MESSAGE_TYPE_UNKNOWN;
+import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newWriteableBuffer;
+import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.pourAll;
 
 public class WebSocketImpl implements WebSocket, TransportLayer {
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(WebSocketImpl.class);
 
-    private int maxFrameSize = (4 * 1024) + (16 * WebSocketHeader.MED_HEADER_LENGTH_MASKED);
+    private final int maxFrameSize = (4 * 1024) + (16 * WebSocketHeader.MED_HEADER_LENGTH_MASKED);
     private boolean tailClosed = false;
     private final ByteBuffer inputBuffer;
     private boolean headClosed = false;
@@ -280,13 +278,13 @@ public class WebSocketImpl implements WebSocket, TransportLayer {
         private void processInput() throws TransportException {
             switch (webSocketState) {
                 case PN_WS_CONNECTING:
-                	inputBuffer.mark();
+                    inputBuffer.mark();
                     if (webSocketHandler.validateUpgradeReply(inputBuffer)) {
                         webSocketState = WebSocketState.PN_WS_CONNECTED_FLOW;
                     } else {
-                    	// Input data was incomplete. Reset buffer position and wait for another call after more data arrives.
-                    	inputBuffer.reset();
-                    	TRACE_LOGGER.warn("Websocket connecting response incomplete");
+                        // Input data was incomplete. Reset buffer position and wait for another call after more data arrives.
+                        inputBuffer.reset();
+                        TRACE_LOGGER.warn("Websocket connecting response incomplete");
                     }
                     inputBuffer.compact();
                     break;


### PR DESCRIPTION
* Enable build failure on checkstyles
  * Before, the errors would show up on console, but the build would still succeed
* Fixes the checkstyle errors:
  * Change tabs to spaces
  * Fix lines longer than 150 characters
  * Fix * imports
  * Format javadocs