### PR TITLE
Adds an automatic-module-name to MANIFEST.MF

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,13 +1,11 @@
-<?xml version="1.0"?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  Copyright (c) Microsoft. All rights reserved.
  Licensed under the MIT license. See LICENSE file in the project root for full license information.
 -->
-
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <!--
     The original file came from here:
@@ -48,6 +46,11 @@
         <property name="eachLine" value="true"/>
     </module>
 
+    <module name="LineLength">
+        <property name="max" value="150"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
     <module name="TreeWalker">
         <!-- Make the @SuppressWarnings annotations available to Checkstyle -->
         <module name="SuppressWarningsHolder"/>
@@ -64,10 +67,6 @@
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
-        <module name="LineLength">
-            <property name="max" value="150"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
         <module name="OneTopLevelClass"/>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>com.microsoft.azure.proton.transport</Automatic-Module-Name>
+                            <Automatic-Module-Name>com.microsoft.azure.qpid.protonj.extensions</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                     <outputDirectory>${packageOutputDirectory}</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>qpid-proton-j-extensions</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
 
     <licenses>
         <license>
@@ -95,6 +95,11 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${maven-jar-plugin.version}</version>
                 <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <automatic-module-name>com.microsoft.azure.proton.transport</automatic-module-name>
+                        </manifestEntries>
+                    </archive>
                     <outputDirectory>${packageOutputDirectory}</outputDirectory>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -37,22 +37,22 @@
         <packageOutputDirectory>${project.build.directory}</packageOutputDirectory>
 
         <!-- Product dependency versions -->
-        <proton-j-version>0.31.0</proton-j-version>
-        <slf4j-version>1.8.0-alpha2</slf4j-version>
+        <proton-j-version>0.33.2</proton-j-version>
+        <slf4j-version>1.7.28</slf4j-version>
 
         <!-- Test dependency versions -->
         <junit-version>4.12</junit-version>
-        <mockito-version>2.28.2</mockito-version>
+        <mockito-version>3.0.0</mockito-version>
 
         <!-- Maven tool versions -->
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
-        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
-        <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
-        <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
 
         <!-- Build tools -->
-        <checkstyle.version>8.18</checkstyle.version>
+        <checkstyle.version>8.24</checkstyle.version>
     </properties>
 
     <build>
@@ -97,7 +97,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <automatic-module-name>com.microsoft.azure.proton.transport</automatic-module-name>
+                            <Automatic-Module-Name>com.microsoft.azure.proton.transport</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                     <outputDirectory>${packageOutputDirectory}</outputDirectory>


### PR DESCRIPTION
* Updates dependencies to match the ones in Azure SDK for Java.
* Fixes checkstyle error.
* To support JDK 9 libraries, this adds an automatic-module-name.
  * This doesn't modularise the library though.
* Related issue in proton-j:https://issues.apache.org/jira/browse/PROTON-2158