### PR TITLE
Add constructor to WebsocketImpl that takes a custom max frame size

### DIFF
--- a/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketImpl.java
@@ -76,6 +76,24 @@ public class WebSocketImpl implements WebSocket, TransportLayer {
         isWebSocketEnabled = false;
     }
 
+    /**
+     * Create WebSocket transport layer - which, after configuring using
+     * the {@link #configure(String, String, String, int, String, Map, WebSocketHandler)} API
+     * is ready for layering in qpid-proton-j transport layers, using
+     * {@link org.apache.qpid.proton.engine.impl.TransportInternal#addTransportLayer(TransportLayer)} API.
+     * @param customMaxFrameSize the maximum frame size that this layer will buffer for
+     */
+    public WebSocketImpl(int customMaxFrameSize) {
+        inputBuffer = newWriteableBuffer(customMaxFrameSize);
+        outputBuffer = newWriteableBuffer(customMaxFrameSize);
+        pingBuffer = newWriteableBuffer(customMaxFrameSize);
+        wsInputBuffer = newWriteableBuffer(customMaxFrameSize);
+        tempBuffer = newWriteableBuffer(customMaxFrameSize);
+        lastType = WEB_SOCKET_MESSAGE_TYPE_UNKNOWN;
+        lastLength = 0;
+        isWebSocketEnabled = false;
+    }
+
     @Override
     public TransportWrapper wrap(final TransportInput input, final TransportOutput output) {
         return new WebSocketSniffer(new WebSocketTransportWrapper(input, output), new PlainTransportWrapper(output, input)) {

--- a/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketImpl.java
@@ -30,7 +30,7 @@ import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.pourAll;
 public class WebSocketImpl implements WebSocket, TransportLayer {
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(WebSocketImpl.class);
 
-    private final int maxFrameSize = (4 * 1024) + (16 * WebSocketHeader.MED_HEADER_LENGTH_MASKED);
+    private static final int maxFrameSize = (4 * 1024) + (16 * WebSocketHeader.MED_HEADER_LENGTH_MASKED);
     private boolean tailClosed = false;
     private final ByteBuffer inputBuffer;
     private boolean headClosed = false;
@@ -66,14 +66,7 @@ public class WebSocketImpl implements WebSocket, TransportLayer {
      * {@link org.apache.qpid.proton.engine.impl.TransportInternal#addTransportLayer(TransportLayer)} API.
      */
     public WebSocketImpl() {
-        inputBuffer = newWriteableBuffer(maxFrameSize);
-        outputBuffer = newWriteableBuffer(maxFrameSize);
-        pingBuffer = newWriteableBuffer(maxFrameSize);
-        wsInputBuffer = newWriteableBuffer(maxFrameSize);
-        tempBuffer = newWriteableBuffer(maxFrameSize);
-        lastType = WEB_SOCKET_MESSAGE_TYPE_UNKNOWN;
-        lastLength = 0;
-        isWebSocketEnabled = false;
+        this(maxFrameSize);
     }
 
     /**

--- a/src/test/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketImplTest.java
@@ -86,6 +86,28 @@ public class WebSocketImplTest {
     }
 
     @Test
+    public void testConstructorWithCustomBufferSize() {
+        init();
+
+        int customBufferSize = 10;
+        WebSocketImpl webSocketImpl = new WebSocketImpl(customBufferSize);
+
+        ByteBuffer inputBuffer = webSocketImpl.getInputBuffer();
+        ByteBuffer outputBuffer = webSocketImpl.getOutputBuffer();
+        ByteBuffer pingBuffer = webSocketImpl.getPingBuffer();
+
+        assertNotNull(inputBuffer);
+        assertNotNull(outputBuffer);
+        assertNotNull(pingBuffer);
+
+        assertEquals(inputBuffer.capacity(), customBufferSize);
+        assertEquals(outputBuffer.capacity(), customBufferSize);
+        assertEquals(pingBuffer.capacity(), customBufferSize);
+
+        assertFalse(webSocketImpl.getEnabled());
+    }
+
+    @Test
     public void testConfigure_handler_null() {
         init();
 


### PR DESCRIPTION
The default max frame size is far too small considering IotHub supports messages up to 256kb, so this new constructor allows more flexibility for large messages