### PR TITLE
Update dependencies and mac os version

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -205,9 +205,6 @@
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
-        <module name="CustomImportOrder">
-            <property name="separateLineBetweenGroups" value="true"/>
-        </module>
         <module name="MethodParamPad"/>
         <module name="ParenPad"/>
         <module name="OperatorWrap">
@@ -238,11 +235,8 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>

--- a/ci.yml
+++ b/ci.yml
@@ -65,7 +65,7 @@ stages:
               cp output/com/microsoft/azure/qpid-proton-j-extensions/**/* $(Build.ArtifactStagingDirectory)
               rm $(Build.ArtifactStagingDirectory)/*.sha1
               rm $(Build.ArtifactStagingDirectory)/*.md5
-              
+
             displayName: Flatten and copy build outputs
 
           - publish: $(Build.ArtifactStagingDirectory)
@@ -83,7 +83,7 @@ stages:
               JavaVersion: '1.8'
             macOS - Java 8:
               OSName: 'macOS'
-              OSVmImage: 'macOS-10.13'
+              OSVmImage: 'macOS-10.15'
               ProfileFlag: ''
               JavaVersion: '1.8'
             Windows - Java 8:
@@ -98,7 +98,7 @@ stages:
               JavaVersion: '1.11'
             macOS - Java LTS:
               OSName: 'macOS'
-              OSVmImage: 'macOS-10.13'
+              OSVmImage: 'macOS-10.15'
               ProfileFlag: '-Djava-lts'
               JavaVersion: '1.11'
             Windows - Java LTS:

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
 
         <!-- Build tools -->
-        <checkstyle.version>8.24</checkstyle.version>
+        <checkstyle.version>8.29</checkstyle.version>
     </properties>
 
     <build>


### PR DESCRIPTION
mac OS 10.13 is no longer supported on azure pipelines. Updates this to 10.15. Also, updates checkstyle rules.