### PR TITLE
Small changes to maintain java 7 compatibility

### DIFF
--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
@@ -67,9 +67,9 @@ public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcesso
         if (logger.isInfoEnabled()) {
             logger.info("Headers added are:");
 
-            headers.forEach((key, value) -> {
-                logger.info("{}: {}", key, value);
-            });
+            for (String header : headers.keySet()) {
+                logger.info("{}: {}", header, headers.get(header));
+            }
         }
 
         return headers;
@@ -94,9 +94,9 @@ public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcesso
         if (logger.isInfoEnabled()) {
             logger.info("Challenge questions are: ");
 
-            challengeQuestionValues.forEach((key, value) -> {
-                logger.info("{}: {}", key, value);
-            });
+            for (String challengeQuestion : challengeQuestionValues.keySet()) {
+                logger.info("{}: {}", challengeQuestion, headers.get(challengeQuestionValues.get(challengeQuestion)));
+            }
         }
     }
 

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
@@ -31,10 +31,10 @@ public class ProxyHandlerImpl implements ProxyHandler {
                 String.format(Locale.ROOT, CONNECT_REQUEST, hostName, NEW_LINE));
 
         if (additionalHeaders != null) {
-            additionalHeaders.forEach((header, value) -> {
-                connectRequestBuilder.append(String.format(HEADER_FORMAT, header, value));
+            for (String header : additionalHeaders.keySet()) {
+                connectRequestBuilder.append(String.format(HEADER_FORMAT, header, additionalHeaders.get(header)));
                 connectRequestBuilder.append(NEW_LINE);
-            });
+            }
         }
 
         connectRequestBuilder.append(NEW_LINE);

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -21,13 +21,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.BASIC;
 import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.DIGEST;
@@ -232,7 +232,7 @@ public class ProxyImpl implements Proxy, TransportLayer {
                         if (LOGGER.isErrorEnabled()) {
                             LOGGER.error("Proxy authentication required. User configured: '{}', but supported proxy authentication methods are: {}",
                                     proxyConfiguration.authentication(),
-                                    supportedTypes.stream().map(Enum::toString).collect(Collectors.joining(",")));
+                                    Arrays.toString(supportedTypes.toArray()).replace("[", "").replace("]", ""));
                         }
 
                         closeTailProxyError(PROXY_CONNECT_USER_ERROR + PROXY_CONNECT_FAILED + challenge);


### PR DESCRIPTION
Not changing project target/source versions because tests currently use lambda functions which don't exist in 7.

For source code that is shipped though, these few instances of lambda functions can be re-written to be java 7 compatible

Azure IoT SDK tries to be java 7 compatible, so we need these changes in order to build