### PR TITLE
Disconnect from the Azure SDK EngSys for release.

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -128,13 +128,3 @@ stages:
             inputs:
               mergeTestResults: true
               testRunTitle: '$(OSName) on Java $(JavaVersion)'
-
-  # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - template: pipelines/stages/archetype-java-release.yml@azure-sdk-build-tools
-      parameters:
-        DependsOn: Build
-        ArtifactName: packages
-        Artifacts:
-          - name: qpid-proton-j-extensions
-            safeName: qpidprotonjextensions


### PR DESCRIPTION
This PR removes the conditional stage which attaches this pipeline to the Azure SDK Engineering System. We've decided that its not going to be viable to maintain the Azure SDK for Java release templates such that it can support external repositories so this is a consequence.

We could choose to migrate this library into the Azure SDK for Java repo if we want to leverage our release pipelines. Otherwise the guidance will be to use the partner release pipelines.