### PR TITLE
Improve proxy to accept successful responses other than "200 Connected"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 
         <!-- Test dependency versions -->
         <junit-version>4.13.1</junit-version>
+		<junit-params-version>5.8.0-M1</junit-params-version>
         <mockito-version>3.0.0</mockito-version>
 
         <!-- Maven tool versions -->
@@ -160,6 +161,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit-version}</version>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-params-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
@@ -56,8 +56,7 @@ public class ProxyHandlerImpl implements ProxyHandler {
             final Scanner responseScanner = new Scanner(response);
             if (responseScanner.hasNextLine()) {
                 final String firstLine = responseScanner.nextLine();
-                if ((firstLine.toLowerCase().contains("http/1.1") || firstLine.toLowerCase().contains("http/1.0"))
-                        && firstLine.matches("(.*)2[0-9][0-9](.*)")) {
+                if (firstLine.toLowerCase().trim().matches("^^http\\/(1.0|1.1)\\s(200|201|202|203|204|205|206)\\s\\w.*$")) {
                     return new ProxyResponseResult(true, null);
                 }
             }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
@@ -12,6 +12,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.regex.Pattern;
+import java.util.function.Predicate;
 
 public class ProxyHandlerImpl implements ProxyHandler {
     /**
@@ -20,7 +22,9 @@ public class ProxyHandlerImpl implements ProxyHandler {
     static final String CONNECT_REQUEST = "CONNECT %1$s HTTP/1.1%2$sHost: %1$s%2$sConnection: Keep-Alive%2$s";
     static final String HEADER_FORMAT = "%s: %s";
     static final String NEW_LINE = "\r\n";
-
+    private final Pattern successStatusLine = Pattern.compile("^http/1\\.(0|1) (?<statusCode>2[0-9]{2})", Pattern.CASE_INSENSITIVE);
+    private final Predicate<String> successStatusLinePredicate = successStatusLine.asPredicate();
+    
     /**
      * {@inheritDoc}
      */
@@ -56,7 +60,7 @@ public class ProxyHandlerImpl implements ProxyHandler {
             final Scanner responseScanner = new Scanner(response);
             if (responseScanner.hasNextLine()) {
                 final String firstLine = responseScanner.nextLine();
-                if (firstLine.toLowerCase().trim().matches("^http\\/(1.0|1.1)\\s(200|201|202|203|204|205|206)\\s\\w.*$")) {
+                if (successStatusLinePredicate.test(firstLine)) {
                     return new ProxyResponseResult(true, null);
                 }
             }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
@@ -58,7 +58,7 @@ public class ProxyHandlerImpl implements ProxyHandler {
                 final String firstLine = responseScanner.nextLine();
                 if ((firstLine.toLowerCase().contains("http/1.1") || firstLine.toLowerCase().contains("http/1.0"))
                         && firstLine.contains("200")
-                        && firstLine.toLowerCase().contains("connection established")) {
+                        && (firstLine.toLowerCase().contains("connection established") || firstLine.toLowerCase().contains("connected"))) {
                     return new ProxyResponseResult(true, null);
                 }
             }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
@@ -56,7 +56,7 @@ public class ProxyHandlerImpl implements ProxyHandler {
             final Scanner responseScanner = new Scanner(response);
             if (responseScanner.hasNextLine()) {
                 final String firstLine = responseScanner.nextLine();
-                if (firstLine.toLowerCase().trim().matches("^^http\\/(1.0|1.1)\\s(200|201|202|203|204|205|206)\\s\\w.*$")) {
+                if (firstLine.toLowerCase().trim().matches("^http\\/(1.0|1.1)\\s(200|201|202|203|204|205|206)\\s\\w.*$")) {
                     return new ProxyResponseResult(true, null);
                 }
             }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
@@ -57,8 +57,7 @@ public class ProxyHandlerImpl implements ProxyHandler {
             if (responseScanner.hasNextLine()) {
                 final String firstLine = responseScanner.nextLine();
                 if ((firstLine.toLowerCase().contains("http/1.1") || firstLine.toLowerCase().contains("http/1.0"))
-                        && firstLine.contains("200")
-                        && (firstLine.toLowerCase().contains("connection established") || firstLine.toLowerCase().contains("connected"))) {
+                        && firstLine.matches("(.*)2[0-9][0-9](.*)")) {
                     return new ProxyResponseResult(true, null);
                 }
             }

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
@@ -8,6 +8,8 @@ package com.microsoft.azure.proton.transport.proxy.impl;
 import com.microsoft.azure.proton.transport.proxy.ProxyHandler;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -34,9 +36,10 @@ public class ProxyHandlerImplTest {
         Assert.assertEquals(expectedProxyRequest, actualProxyRequest);
     }
 
-    @Test
-    public void testValidateProxyResponseOnSuccess() {
-        final String validResponse = "HTTP/1.1 200 Connection Established\r\n" +
+    @ParameterizedTest
+	@ValueSource(ints = {200, 201, 202, 203, 204, 205, 206})
+    public void testValidateProxyResponseOnSuccess(int httpCode) {
+        final String validResponse = "HTTP/1.1 " + httpCode + "Connection Established\r\n" +
                 "FiddlerGateway: Direct\r\n" +
                 "StartTime: 13:08:21.574\r\n" +
                 "Connection: close\r\n\r\n";
@@ -52,145 +55,10 @@ public class ProxyHandlerImplTest {
 
         Assert.assertEquals(0, buffer.remaining());
     }
-	
-	    @Test
-    public void testValidateProxyResponseOnSuccess201() {
-        final String validResponse = "HTTP/1.1 201 Connected\r\n" +
-                "FiddlerGateway: Direct\r\n" +
-                "StartTime: 13:08:21.574\r\n" +
-                "Connection: close\r\n\r\n";
-        final ByteBuffer buffer = ByteBuffer.allocate(1024);
-        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
-        buffer.flip();
-
-        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
-
-        Assert.assertTrue(responseResult.getIsSuccess());
-        Assert.assertNull(responseResult.getError());
-
-        Assert.assertEquals(0, buffer.remaining());
-    }
-	
-		    @Test
-    public void testValidateProxyResponseOnSuccess202() {
-        final String validResponse = "HTTP/1.1 202 Connected\r\n" +
-                "FiddlerGateway: Direct\r\n" +
-                "StartTime: 13:08:21.574\r\n" +
-                "Connection: close\r\n\r\n";
-        final ByteBuffer buffer = ByteBuffer.allocate(1024);
-        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
-        buffer.flip();
-
-        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
-
-        Assert.assertTrue(responseResult.getIsSuccess());
-        Assert.assertNull(responseResult.getError());
-
-        Assert.assertEquals(0, buffer.remaining());
-    }
-	
-		    @Test
-    public void testValidateProxyResponseOnSuccess203() {
-        final String validResponse = "HTTP/1.1 203 Connected\r\n" +
-                "FiddlerGateway: Direct\r\n" +
-                "StartTime: 13:08:21.574\r\n" +
-                "Connection: close\r\n\r\n";
-        final ByteBuffer buffer = ByteBuffer.allocate(1024);
-        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
-        buffer.flip();
-
-        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
-
-        Assert.assertTrue(responseResult.getIsSuccess());
-        Assert.assertNull(responseResult.getError());
-
-        Assert.assertEquals(0, buffer.remaining());
-    }
-	
-		    @Test
-    public void testValidateProxyResponseOnSuccess204() {
-        final String validResponse = "HTTP/1.1 204 Connected\r\n" +
-                "FiddlerGateway: Direct\r\n" +
-                "StartTime: 13:08:21.574\r\n" +
-                "Connection: close\r\n\r\n";
-        final ByteBuffer buffer = ByteBuffer.allocate(1024);
-        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
-        buffer.flip();
-
-        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
-
-        Assert.assertTrue(responseResult.getIsSuccess());
-        Assert.assertNull(responseResult.getError());
-
-        Assert.assertEquals(0, buffer.remaining());
-    }
-	
-		    @Test
-    public void testValidateProxyResponseOnSuccess205() {
-        final String validResponse = "HTTP/1.1 205 Connected\r\n" +
-                "FiddlerGateway: Direct\r\n" +
-                "StartTime: 13:08:21.574\r\n" +
-                "Connection: close\r\n\r\n";
-        final ByteBuffer buffer = ByteBuffer.allocate(1024);
-        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
-        buffer.flip();
-
-        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
-
-        Assert.assertTrue(responseResult.getIsSuccess());
-        Assert.assertNull(responseResult.getError());
-
-        Assert.assertEquals(0, buffer.remaining());
-    }
-	
-		    @Test
-    public void testValidateProxyResponseOnSuccess206() {
-        final String validResponse = "HTTP/1.1 206 Connected\r\n" +
-                "FiddlerGateway: Direct\r\n" +
-                "StartTime: 13:08:21.574\r\n" +
-                "Connection: close\r\n\r\n";
-        final ByteBuffer buffer = ByteBuffer.allocate(1024);
-        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
-        buffer.flip();
-
-        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
-
-        Assert.assertTrue(responseResult.getIsSuccess());
-        Assert.assertNull(responseResult.getError());
-
-        Assert.assertEquals(0, buffer.remaining());
-    }
-	
 
     @Test
     public void testValidateProxyResponseOnFailure() {
         final String failResponse = "HTTP/1.1 407 Proxy Auth Required\r\n" +
-                "Connection: close\r\n" +
-                "Proxy-Authenticate: Basic realm=\"FiddlerProxy (user: 1, pass: 1)\"\r\n" +
-                "Content-Type: text/html\r\n" +
-                "<html><body>[Fiddler] Proxy Authentication Required.<BR></body></html>\r\n\r\n";
-        final ByteBuffer buffer = ByteBuffer.allocate(1024);
-        buffer.put(failResponse.getBytes(StandardCharsets.UTF_8));
-        buffer.flip();
-
-        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
-
-        Assert.assertTrue(!responseResult.getIsSuccess());
-        Assert.assertEquals(failResponse, responseResult.getError());
-
-        Assert.assertEquals(0, buffer.remaining());
-    }
-	
-	@Test
-    public void testValidateProxyResponseOnEmptyReasonPhrase() {
-        final String failResponse = "HTTP/1.1 200\r\n" +
                 "Connection: close\r\n" +
                 "Proxy-Authenticate: Basic realm=\"FiddlerProxy (user: 1, pass: 1)\"\r\n" +
                 "Content-Type: text/html\r\n" +

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
@@ -52,10 +52,145 @@ public class ProxyHandlerImplTest {
 
         Assert.assertEquals(0, buffer.remaining());
     }
+	
+	    @Test
+    public void testValidateProxyResponseOnSuccess201() {
+        final String validResponse = "HTTP/1.1 201 Connected\r\n" +
+                "FiddlerGateway: Direct\r\n" +
+                "StartTime: 13:08:21.574\r\n" +
+                "Connection: close\r\n\r\n";
+        final ByteBuffer buffer = ByteBuffer.allocate(1024);
+        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
+        buffer.flip();
+
+        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
+        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
+
+        Assert.assertTrue(responseResult.getIsSuccess());
+        Assert.assertNull(responseResult.getError());
+
+        Assert.assertEquals(0, buffer.remaining());
+    }
+	
+		    @Test
+    public void testValidateProxyResponseOnSuccess202() {
+        final String validResponse = "HTTP/1.1 202 Connected\r\n" +
+                "FiddlerGateway: Direct\r\n" +
+                "StartTime: 13:08:21.574\r\n" +
+                "Connection: close\r\n\r\n";
+        final ByteBuffer buffer = ByteBuffer.allocate(1024);
+        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
+        buffer.flip();
+
+        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
+        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
+
+        Assert.assertTrue(responseResult.getIsSuccess());
+        Assert.assertNull(responseResult.getError());
+
+        Assert.assertEquals(0, buffer.remaining());
+    }
+	
+		    @Test
+    public void testValidateProxyResponseOnSuccess203() {
+        final String validResponse = "HTTP/1.1 203 Connected\r\n" +
+                "FiddlerGateway: Direct\r\n" +
+                "StartTime: 13:08:21.574\r\n" +
+                "Connection: close\r\n\r\n";
+        final ByteBuffer buffer = ByteBuffer.allocate(1024);
+        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
+        buffer.flip();
+
+        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
+        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
+
+        Assert.assertTrue(responseResult.getIsSuccess());
+        Assert.assertNull(responseResult.getError());
+
+        Assert.assertEquals(0, buffer.remaining());
+    }
+	
+		    @Test
+    public void testValidateProxyResponseOnSuccess204() {
+        final String validResponse = "HTTP/1.1 204 Connected\r\n" +
+                "FiddlerGateway: Direct\r\n" +
+                "StartTime: 13:08:21.574\r\n" +
+                "Connection: close\r\n\r\n";
+        final ByteBuffer buffer = ByteBuffer.allocate(1024);
+        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
+        buffer.flip();
+
+        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
+        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
+
+        Assert.assertTrue(responseResult.getIsSuccess());
+        Assert.assertNull(responseResult.getError());
+
+        Assert.assertEquals(0, buffer.remaining());
+    }
+	
+		    @Test
+    public void testValidateProxyResponseOnSuccess205() {
+        final String validResponse = "HTTP/1.1 205 Connected\r\n" +
+                "FiddlerGateway: Direct\r\n" +
+                "StartTime: 13:08:21.574\r\n" +
+                "Connection: close\r\n\r\n";
+        final ByteBuffer buffer = ByteBuffer.allocate(1024);
+        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
+        buffer.flip();
+
+        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
+        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
+
+        Assert.assertTrue(responseResult.getIsSuccess());
+        Assert.assertNull(responseResult.getError());
+
+        Assert.assertEquals(0, buffer.remaining());
+    }
+	
+		    @Test
+    public void testValidateProxyResponseOnSuccess206() {
+        final String validResponse = "HTTP/1.1 206 Connected\r\n" +
+                "FiddlerGateway: Direct\r\n" +
+                "StartTime: 13:08:21.574\r\n" +
+                "Connection: close\r\n\r\n";
+        final ByteBuffer buffer = ByteBuffer.allocate(1024);
+        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
+        buffer.flip();
+
+        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
+        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
+
+        Assert.assertTrue(responseResult.getIsSuccess());
+        Assert.assertNull(responseResult.getError());
+
+        Assert.assertEquals(0, buffer.remaining());
+    }
+	
 
     @Test
     public void testValidateProxyResponseOnFailure() {
         final String failResponse = "HTTP/1.1 407 Proxy Auth Required\r\n" +
+                "Connection: close\r\n" +
+                "Proxy-Authenticate: Basic realm=\"FiddlerProxy (user: 1, pass: 1)\"\r\n" +
+                "Content-Type: text/html\r\n" +
+                "<html><body>[Fiddler] Proxy Authentication Required.<BR></body></html>\r\n\r\n";
+        final ByteBuffer buffer = ByteBuffer.allocate(1024);
+        buffer.put(failResponse.getBytes(StandardCharsets.UTF_8));
+        buffer.flip();
+
+        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
+        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
+
+        Assert.assertTrue(!responseResult.getIsSuccess());
+        Assert.assertEquals(failResponse, responseResult.getError());
+
+        Assert.assertEquals(0, buffer.remaining());
+    }
+	
+	@Test
+    public void testValidateProxyResponseOnEmptyReasonPhrase() {
+        final String failResponse = "HTTP/1.1 200\r\n" +
                 "Connection: close\r\n" +
                 "Proxy-Authenticate: Basic realm=\"FiddlerProxy (user: 1, pass: 1)\"\r\n" +
                 "Content-Type: text/html\r\n" +


### PR DESCRIPTION
Hi team,

I'm opening this PR for a customer suggested improvement to the current proxy implementation.
**Issue:**
The current implementation only accepts "200 Connected" responses from the proxy.
Some proxies seem to be replying with slightly different responses, such as "200 Connection established" rather than "200 Connected", which we are expecting.

**Fix:**
The change implemented in this fork would allow "connection established" as a valid response.

**Suggestion:**
As further suggested and discussed via email, the likely sufficient and right validation would be to accept response '2xx' response codes. 