### PR TITLE
42 - 

### DIFF
--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
@@ -48,6 +48,15 @@ public interface ProxyHandler {
     String createProxyRequest(String hostName, Map<String, String> additionalHeaders);
 
     /**
+     * Creates a CONNECT request to the provided {@code hostName} and adds {@code additionalHeaders} to the request.
+     *
+     * @param hostName Name of the host to connect to.
+     * @param additionalHeaders Optional. Additional headers to add to the request.
+     * @return A byte array stream representing the HTTP CONNECT request.
+     */
+    byte[] createProxyRequestStream(String hostName, Map<String, String> additionalHeaders);
+
+    /**
      * Verifies that {@code buffer} contains a successful CONNECT response.
      *
      * @param buffer Buffer containing the HTTP response.

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
@@ -35,6 +35,18 @@ public class ProxyHandlerImpl implements ProxyHandler {
      */
     @Override
     public String createProxyRequest(String hostName, Map<String, String> additionalHeaders) {
+        return getConnectionRequest(hostName, additionalHeaders);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte[] createProxyRequestStream(String hostName, Map<String, String> additionalHeaders) {
+       return getConnectionRequest(hostName, additionalHeaders).getBytes(StandardCharsets.ISO_8859_1);
+    }
+
+    private String getConnectionRequest(String hostName, Map<String, String> additionalHeaders) {
         final StringBuilder connectRequestBuilder = new StringBuilder();
         connectRequestBuilder.append(
                 String.format(Locale.ROOT, CONNECT_REQUEST, hostName, NEW_LINE));

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
@@ -43,7 +43,7 @@ public class ProxyHandlerImpl implements ProxyHandler {
      */
     @Override
     public byte[] createProxyRequestStream(String hostName, Map<String, String> additionalHeaders) {
-       return getConnectionRequest(hostName, additionalHeaders).getBytes(StandardCharsets.ISO_8859_1);
+        return getConnectionRequest(hostName, additionalHeaders).getBytes(StandardCharsets.ISO_8859_1);
     }
 
     private String getConnectionRequest(String hostName, Map<String, String> additionalHeaders) {

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
@@ -109,4 +109,26 @@ public class ProxyHandlerImplTest {
 
         Assert.assertEquals(0, buffer.remaining());
     }
+
+    @Test
+    public void testCreateProxyRequestStream() {
+        final String hostName = "testHostName";
+        final HashMap<String, String> headers = new HashMap<>();
+        headers.put("header1", "headervalue1");
+        headers.put("header2", "headervalue2");
+
+        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
+        final byte[] actualProxyRequest = proxyHandler.createProxyRequestStream(hostName, headers);
+
+        final String actualProxyRequestString = new String(actualProxyRequest,StandardCharsets.ISO_8859_1);
+
+        final String expectedProxyRequest = String.join("\r\n", "CONNECT testHostName HTTP/1.1",
+            "Host: testHostName",
+            "Connection: Keep-Alive",
+            "header2: headervalue2",
+            "header1: headervalue1",
+            "\r\n");
+
+        Assert.assertEquals(expectedProxyRequest, actualProxyRequestString);
+    }
 }

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
@@ -120,7 +120,7 @@ public class ProxyHandlerImplTest {
         final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
         final byte[] actualProxyRequest = proxyHandler.createProxyRequestStream(hostName, headers);
 
-        final String actualProxyRequestString = new String(actualProxyRequest,StandardCharsets.ISO_8859_1);
+        final String actualProxyRequestString = new String(actualProxyRequest, StandardCharsets.ISO_8859_1);
 
         final String expectedProxyRequest = String.join("\r\n", "CONNECT testHostName HTTP/1.1",
             "Host: testHostName",


### PR DESCRIPTION
Overview

Connects #42 , adding the new method for returning the proxy connection details as encrypted byte array

Notes

- added `ProxyHandler.createProxyRequestStream` method to address the problem described, that returns proxy connection 
  details as encrypted byte array
- added unit test for the above method , to verify the same.
Testing Instructions

Run mvn:verify command, to run the tests and check for any checkstyle and spotbugs issues.