### PR TITLE
Support authentication response are multiple frames

### DIFF
--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/HttpStatusLine.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/HttpStatusLine.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.proton.transport.proxy;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * The first line in an HTTP 1.0/1.1 response. Consists of the HTTP protocol version, status code, and a reason phrase
+ * for the HTTP response.
+ *
+ * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html">RFC 2616</a>
+ */
+public class HttpStatusLine {
+    private final String httpVersion;
+    private final int statusCode;
+    private final String reason;
+
+    /**
+     * Creates a new instance of {@link HttpStatusLine}.
+     *
+     * @param protocolVersion The HTTP protocol version. For example, 1.0, 1.1.
+     * @param statusCode A numeric status code for the HTTP response.
+     * @param reason Textual phrase representing the HTTP status code.
+     */
+    private HttpStatusLine(String protocolVersion, int statusCode, String reason) {
+        this.httpVersion = Objects.requireNonNull(protocolVersion, "'httpVersion' cannot be null.");
+        this.statusCode = statusCode;
+        this.reason = Objects.requireNonNull(reason, "'reason' cannot be null.");
+    }
+
+    /**
+     * Parses the provided {@code statusLine} into an HTTP status line.
+     *
+     * @param line Line to parse into an HTTP status line.
+     * @return A new instance of {@link HttpStatusLine} representing the given {@code statusLine}.
+     * @throws IllegalArgumentException if {@code line} is not the correct format of an HTTP status line. If it
+     *         does not have a protocol version, status code, or reason component. Or, if the HTTP protocol version
+     *         cannot be parsed.
+     */
+    public static HttpStatusLine create(String line) {
+        final String[] components = line.split(" ", 3);
+        if (components.length != 3) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT,
+                    "HTTP status-line is invalid. Line: %s", line));
+        }
+
+        final String[] protocol = components[0].split("/", 2);
+        if (protocol.length != 2) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT,
+                    "Protocol is invalid, expected HTTP/{version}. Actual: %s", components[0]));
+        }
+
+        return new HttpStatusLine(protocol[1], Integer.parseInt(components[1]), components[2]);
+    }
+
+    /**
+     * Gets the HTTP protocol version.
+     *
+     * @return The HTTP protocol version.
+     */
+    public String getProtocolVersion() {
+        return this.httpVersion;
+    }
+
+    /**
+     * Gets the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getStatusCode() {
+        return this.statusCode;
+    }
+
+    /**
+     * Gets the textual representation for the HTTP status code.
+     *
+     * @return The textual representation for the HTTP status code.
+     */
+    public String getReason() {
+        return this.reason;
+    }
+}

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/HttpStatusLine.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/HttpStatusLine.java
@@ -54,7 +54,15 @@ public class HttpStatusLine {
                     "Protocol is invalid, expected HTTP/{version}. Actual: %s", components[0]));
         }
 
-        return new HttpStatusLine(protocol[1], Integer.parseInt(components[1]), components[2]);
+        int statusCode;
+        try {
+            statusCode = Integer.parseInt(components[1]);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format(Locale.US,
+                    "HTTP Status code '%s' is not valid.", components[1]), e);
+        }
+
+        return new HttpStatusLine(protocol[1], statusCode, components[2]);
     }
 
     /**

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/HttpStatusLine.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/HttpStatusLine.java
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) Microsoft. All rights reserved.
- * Licensed under the MIT license. See LICENSE file in the project root for full license information.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 package com.microsoft.azure.proton.transport.proxy;
 
@@ -14,7 +12,7 @@ import java.util.Objects;
  *
  * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html">RFC 2616</a>
  */
-public class HttpStatusLine {
+public final class HttpStatusLine {
     private final String httpVersion;
     private final int statusCode;
     private final String reason;

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
@@ -3,8 +3,8 @@
 
 package com.microsoft.azure.proton.transport.proxy;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Creates and validates proxy requests and responses.
@@ -15,8 +15,8 @@ public interface ProxyHandler {
      * Represents a response from the proxy.
      */
     class ProxyResponseResult {
-        private final Boolean isSuccess;
-        private final String error;
+        private final boolean isSuccess;
+        private final ProxyResponse response;
 
         /**
          * Creates a new response.
@@ -26,15 +26,19 @@ public interface ProxyHandler {
          */
         public ProxyResponseResult(final Boolean isSuccess, final String error) {
             this.isSuccess = isSuccess;
-            this.error = error;
+            this.response = Objects.requireNonNull(response, "'response' cannot be null.");
         }
 
-        public Boolean getIsSuccess() {
+        public boolean isSuccess() {
             return isSuccess;
         }
 
+        public ProxyResponse getResponse() {
+            return response;
+        }
+
         public String getError() {
-            return error;
+            return isSuccess ? null : response.getError();
         }
     }
 
@@ -48,11 +52,11 @@ public interface ProxyHandler {
     String createProxyRequest(String hostName, Map<String, String> additionalHeaders);
 
     /**
-     * Verifies that {@code buffer} contains a successful CONNECT response.
+     * Verifies that {@code httpResponse} contains a successful CONNECT response.
      *
-     * @param buffer Buffer containing the HTTP response.
+     * @param httpResponse HTTP response to validate for a successful CONNECT response.
      * @return Indicates if CONNECT response contained a success. If not, contains an error indicating why the call was
      *         not successful.
      */
-    ProxyResponseResult validateProxyResponse(ByteBuffer buffer);
+    ProxyResponseResult validateProxyResponse(ProxyResponse httpResponse);
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
@@ -4,43 +4,11 @@
 package com.microsoft.azure.proton.transport.proxy;
 
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Creates and validates proxy requests and responses.
  */
 public interface ProxyHandler {
-
-    /**
-     * Represents a response from the proxy.
-     */
-    class ProxyResponseResult {
-        private final boolean isSuccess;
-        private final ProxyResponse response;
-
-        /**
-         * Creates a new response.
-         *
-         * @param isSuccess {@code true} if it was successful; {@code false} otherwise.
-         * @param response The response from the proxy.
-         */
-        public ProxyResponseResult(final Boolean isSuccess, final ProxyResponse response) {
-            this.isSuccess = isSuccess;
-            this.response = Objects.requireNonNull(response, "'response' cannot be null.");
-        }
-
-        public boolean isSuccess() {
-            return isSuccess;
-        }
-
-        public ProxyResponse getResponse() {
-            return response;
-        }
-
-        public String getError() {
-            return isSuccess ? null : response.getError();
-        }
-    }
 
     /**
      * Creates a CONNECT request to the provided {@code hostName} and adds {@code additionalHeaders} to the request.
@@ -55,8 +23,8 @@ public interface ProxyHandler {
      * Verifies that {@code httpResponse} contains a successful CONNECT response.
      *
      * @param httpResponse HTTP response to validate for a successful CONNECT response.
-     * @return Indicates if CONNECT response contained a success. If not, contains an error indicating why the call was
-     *         not successful.
+     * @return {@code true} if the HTTP response is successful and correct, and {@code false} otherwise.
+     *
      */
-    ProxyResponseResult validateProxyResponse(ProxyResponse httpResponse);
+    boolean validateProxyResponse(ProxyResponse httpResponse);
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyHandler.java
@@ -22,9 +22,9 @@ public interface ProxyHandler {
          * Creates a new response.
          *
          * @param isSuccess {@code true} if it was successful; {@code false} otherwise.
-         * @param error The error from the proxy. Or {@code null} if there was none.
+         * @param response The response from the proxy.
          */
-        public ProxyResponseResult(final Boolean isSuccess, final String error) {
+        public ProxyResponseResult(final Boolean isSuccess, final ProxyResponse response) {
             this.isSuccess = isSuccess;
             this.response = Objects.requireNonNull(response, "'response' cannot be null.");
         }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyResponse.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyResponse.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.proton.transport.proxy;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents an HTTP response from a proxy.
+ */
+public interface ProxyResponse {
+    /**
+     * Gets the headers for the HTTP response.
+     *
+     * @return The headers for the HTTP response.
+     */
+    Map<String, List<String>> getHeaders();
+
+    /**
+     * Gets the HTTP status line.
+     *
+     * @return The HTTP status line.
+     */
+    HttpStatusLine getStatus();
+
+    /**
+     * Gets the HTTP response body.
+     *
+     * @return The HTTP response body.
+     */
+    ByteBuffer getContents();
+
+    /**
+     * Gets the HTTP response body as an error.
+     *
+     * @return If there is no HTTP response body, an empty string is returned.
+     */
+    String getError();
+
+    /**
+     * Gets whether or not the HTTP response is complete. An HTTP response is complete when the HTTP header and body are
+     * received.
+     *
+     * @return {@code true} if the HTTP response is complete, and {@code false} otherwise.
+     */
+    boolean isMissingContent();
+
+    /**
+     * Adds contents to the body if it is missing content.
+     *
+     * @param contents Contents to add to the HTTP body.
+     */
+    void addContent(ByteBuffer contents);
+}

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyResponse.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/ProxyResponse.java
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) Microsoft. All rights reserved.
- * Licensed under the MIT license. See LICENSE file in the project root for full license information.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 package com.microsoft.azure.proton.transport.proxy;
 

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
@@ -9,7 +9,8 @@ import java.util.Locale;
  * Package private constants.
  */
 class Constants {
-    static final String PROXY_AUTHENTICATE_HEADER = "Proxy-Authenticate:";
+    static final String PROXY_AUTHENTICATE = "Proxy-Authenticate";
+    static final String PROXY_AUTHENTICATE_HEADER = PROXY_AUTHENTICATE + ":";
     static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
 
     static final String DIGEST = "Digest";

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
@@ -10,7 +10,6 @@ import java.util.Locale;
  */
 class Constants {
     static final String PROXY_AUTHENTICATE = "Proxy-Authenticate";
-    static final String PROXY_AUTHENTICATE_HEADER = PROXY_AUTHENTICATE + ":";
     static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
 
     static final String DIGEST = "Digest";

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/Constants.java
@@ -18,4 +18,11 @@ class Constants {
     static final String DIGEST_LOWERCASE = Constants.DIGEST.toLowerCase(Locale.ROOT);
 
     static final String CONNECT = "CONNECT";
+
+    static final String PROXY_CONNECT_FAILED = "Proxy connect request failed with error: ";
+    static final String PROXY_CONNECT_USER_ERROR = "User configuration error. Using non-matching proxy authentication.";
+
+    static final int PROXY_HANDSHAKE_BUFFER_SIZE = 4 * 1024; // buffers used only for proxy-handshake
+
+    static final String CONTENT_LENGTH = "Content-Length";
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImpl.java
@@ -28,7 +28,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class DigestProxyChallengeProcessorImpl implements ProxyChallengeProcessor {
     static final String DEFAULT_ALGORITHM = "MD5";
-    private static final String PROXY_AUTH_DIGEST = Constants.PROXY_AUTHENTICATE_HEADER + " " + Constants.DIGEST;
+    private static final String PROXY_AUTH_DIGEST = Constants.DIGEST;
     private static final char[] HEX_CODE = "0123456789ABCDEF".toCharArray();
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
@@ -59,19 +59,17 @@ public class ProxyHandlerImpl implements ProxyHandler {
      * {@inheritDoc}
      */
     @Override
-    public ProxyResponseResult validateProxyResponse(ProxyResponse response) {
+    public boolean validateProxyResponse(ProxyResponse response) {
         Objects.requireNonNull(response, "'response' cannot be null.");
 
         final HttpStatusLine status = response.getStatus();
         if (status == null) {
-            logger.warn("Response does not contain a status line. {}", response);
-            return new ProxyResponseResult(false, response);
+            logger.error("Response does not contain a status line. {}", response);
+            return false;
         }
 
-        final boolean isSuccessful = status.getStatusCode() == 200
+        return status.getStatusCode() == 200
                 && SUPPORTED_VERSIONS.contains(status.getProtocolVersion())
                 && CONNECTION_ESTABLISHED.equalsIgnoreCase(status.getReason());
-
-        return new ProxyResponseResult(isSuccessful, response);
     }
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImpl.java
@@ -3,16 +3,19 @@
 
 package com.microsoft.azure.proton.transport.proxy.impl;
 
+import com.microsoft.azure.proton.transport.proxy.HttpStatusLine;
 import com.microsoft.azure.proton.transport.proxy.Proxy;
 import com.microsoft.azure.proton.transport.proxy.ProxyHandler;
+import com.microsoft.azure.proton.transport.proxy.ProxyResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Scanner;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Implementation class that handles connecting to the proxy.
@@ -27,8 +30,10 @@ public class ProxyHandlerImpl implements ProxyHandler {
     static final String CONNECT_REQUEST = "CONNECT %1$s HTTP/1.1%2$sHost: %1$s%2$sConnection: Keep-Alive%2$s";
     static final String HEADER_FORMAT = "%s: %s";
     static final String NEW_LINE = "\r\n";
-    private final Pattern successStatusLine = Pattern.compile("^http/1\\.(0|1) (?<statusCode>2[0-9]{2})", Pattern.CASE_INSENSITIVE);
-    private final Predicate<String> successStatusLinePredicate = successStatusLine.asPredicate();
+
+    private static final String CONNECTION_ESTABLISHED = "connection established";
+    private static final Set<String> SUPPORTED_VERSIONS = Stream.of("1.1", "1.0").collect(Collectors.toSet());
+    private final Logger logger = LoggerFactory.getLogger(ProxyHandlerImpl.class);
 
     /**
      * {@inheritDoc}
@@ -54,23 +59,19 @@ public class ProxyHandlerImpl implements ProxyHandler {
      * {@inheritDoc}
      */
     @Override
-    public ProxyResponseResult validateProxyResponse(ByteBuffer buffer) {
-        int size = buffer.remaining();
-        String response = null;
+    public ProxyResponseResult validateProxyResponse(ProxyResponse response) {
+        Objects.requireNonNull(response, "'response' cannot be null.");
 
-        if (size > 0) {
-            byte[] responseBytes = new byte[buffer.remaining()];
-            buffer.get(responseBytes);
-            response = new String(responseBytes, StandardCharsets.UTF_8);
-            final Scanner responseScanner = new Scanner(response);
-            if (responseScanner.hasNextLine()) {
-                final String firstLine = responseScanner.nextLine();
-                if (successStatusLinePredicate.test(firstLine)) {
-                    return new ProxyResponseResult(true, null);
-                }
-            }
+        final HttpStatusLine status = response.getStatus();
+        if (status == null) {
+            logger.warn("Response does not contain a status line. {}", response);
+            return new ProxyResponseResult(false, response);
         }
 
-        return new ProxyResponseResult(false, response);
+        final boolean isSuccessful = status.getStatusCode() == 200
+                && SUPPORTED_VERSIONS.contains(status.getProtocolVersion())
+                && CONNECTION_ESTABLISHED.equalsIgnoreCase(status.getReason());
+
+        return new ProxyResponseResult(isSuccessful, response);
     }
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -249,13 +249,13 @@ public class ProxyImpl implements Proxy, TransportLayer {
                         LOGGER.warn("Request is missing content. Waiting for more bytes.");
                         break;
                     }
-
-                    final ProxyResponseResult result = proxyHandler.validateProxyResponse(current);
-                    //Clean up proxy auth response
+                    //Clean up response to prepare for challenge
                     proxyAuthResponse.set(null);
 
+                    final ProxyResponseResult result = proxyHandler.validateProxyResponse(current);
+
                     // When connecting to proxy, it does not challenge us for authentication. If the user has specified
-                    // a configuration and it is not NONE, then we fail due to misconfiguration.
+                    // a configuration, and it is not NONE, then we fail due to misconfiguration.
                     if (result.isSuccess()) {
                         if (proxyConfiguration == null || proxyConfiguration.authentication() == ProxyAuthenticationType.NONE) {
                             proxyState = ProxyState.PN_PROXY_CONNECTED;
@@ -306,6 +306,8 @@ public class ProxyImpl implements Proxy, TransportLayer {
                         LOGGER.warn("Request is missing content. Waiting for more bytes.");
                         break;
                     }
+                    //Clean up
+                    proxyAuthResponse.set(null);
 
                     final ProxyResponseResult challengeResult = proxyHandler.validateProxyResponse(response);
 
@@ -482,7 +484,7 @@ public class ProxyImpl implements Proxy, TransportLayer {
          *
          * @param headers HTTP proxy response headers from service call.
          * @return The supported proxy authentication methods. Or, an empty set if the value of {@code error} is {@code
-         *         null}, an empty string. Or, if it does not contain{@link Constants#PROXY_AUTHENTICATE_HEADER} with
+         *         null}, an empty string. Or, if it does not contain{@link Constants#PROXY_AUTHENTICATE} with
          *         {@link Constants#BASIC_LOWERCASE} or {@link Constants#DIGEST_LOWERCASE}.
          */
         private Set<ProxyAuthenticationType> getAuthenticationTypes(Map<String, List<String>> headers) {

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -8,6 +8,8 @@ import com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType;
 import com.microsoft.azure.proton.transport.proxy.ProxyChallengeProcessor;
 import com.microsoft.azure.proton.transport.proxy.ProxyConfiguration;
 import com.microsoft.azure.proton.transport.proxy.ProxyHandler;
+import com.microsoft.azure.proton.transport.proxy.ProxyHandler.ProxyResponseResult;
+import com.microsoft.azure.proton.transport.proxy.ProxyResponse;
 import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.engine.TransportException;
 import org.apache.qpid.proton.engine.impl.TransportImpl;
@@ -19,16 +21,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Scanner;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.BASIC;
 import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.DIGEST;
+import static com.microsoft.azure.proton.transport.proxy.impl.Constants.PROXY_AUTHENTICATE;
 import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newWriteableBuffer;
 
 /**
@@ -50,28 +56,27 @@ public class ProxyImpl implements Proxy, TransportLayer {
 
     private boolean tailClosed = false;
     private boolean headClosed = false;
-    private boolean isProxyConfigured;
     private String host = "";
     private Map<String, String> headers = null;
     private TransportImpl underlyingTransport;
-    private ProxyState proxyState = ProxyState.PN_PROXY_NOT_STARTED;
     private ProxyHandler proxyHandler;
 
+    private volatile boolean isProxyConfigured;
+    private volatile ProxyState proxyState = ProxyState.PN_PROXY_NOT_STARTED;
+
     /**
-     * Create proxy transport layer - which, after configuring using
-     * the {@link #configure(String, Map, ProxyHandler, Transport)} API
-     * is ready for layering in qpid-proton-j transport layers, using
-     * {@link org.apache.qpid.proton.engine.impl.TransportInternal#addTransportLayer(TransportLayer)} API.
+     * Create proxy transport layer - which, after configuring using the {@link #configure(String, Map, ProxyHandler,
+     * Transport)} API is ready for layering in qpid-proton-j transport layers, using {@link
+     * org.apache.qpid.proton.engine.impl.TransportInternal#addTransportLayer(TransportLayer)} API.
      */
     public ProxyImpl() {
         this(null);
     }
 
     /**
-     * Create proxy transport layer - which, after configuring using
-     * the {@link #configure(String, Map, ProxyHandler, Transport)} API
-     * is ready for layering in qpid-proton-j transport layers, using
-     * {@link org.apache.qpid.proton.engine.impl.TransportInternal#addTransportLayer(TransportLayer)} API.
+     * Create proxy transport layer - which, after configuring using the {@link #configure(String, Map, ProxyHandler,
+     * Transport)} API is ready for layering in qpid-proton-j transport layers, using {@link
+     * org.apache.qpid.proton.engine.impl.TransportInternal#addTransportLayer(TransportLayer)} API.
      *
      * @param configuration Proxy configuration to use.
      */
@@ -133,7 +138,7 @@ public class ProxyImpl implements Proxy, TransportLayer {
         return this.outputBuffer;
     }
 
-    protected Boolean getIsProxyConfigured() {
+    protected boolean getIsProxyConfigured() {
         return this.isProxyConfigured;
     }
 
@@ -180,10 +185,17 @@ public class ProxyImpl implements Proxy, TransportLayer {
         private final TransportOutput underlyingOutput;
         private final ByteBuffer head;
 
+        // Represents a response from a CONNECT request.
+        private final AtomicReference<ProxyResponse> proxyAuthResponse = new AtomicReference<>();
+
+        /**
+         * Creates a transport wrapper that wraps the WebSocket transport input and output.
+         */
         ProxyTransportWrapper(TransportInput input, TransportOutput output) {
             underlyingInput = input;
             underlyingOutput = output;
             head = outputBuffer.asReadOnlyBuffer();
+            head.limit(0);
         }
 
         @Override
@@ -231,62 +243,76 @@ public class ProxyImpl implements Proxy, TransportLayer {
             switch (proxyState) {
                 case PN_PROXY_CONNECTING:
                     inputBuffer.flip();
-                    final ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(inputBuffer);
-                    inputBuffer.compact();
-                    inputBuffer.clear();
+
+                    final ProxyResponse current = readProxyResponse(inputBuffer);
+                    if (current != null && current.isMissingContent()) {
+                        LOGGER.warn("Request is missing content. Waiting for more bytes.");
+                        break;
+                    }
+
+                    final ProxyResponseResult result = proxyHandler.validateProxyResponse(current);
+                    //Clean up proxy auth response
+                    proxyAuthResponse.set(null);
 
                     // When connecting to proxy, it does not challenge us for authentication. If the user has specified
                     // a configuration and it is not NONE, then we fail due to misconfiguration.
-                    if (responseResult.getIsSuccess()) {
+                    if (result.isSuccess()) {
                         if (proxyConfiguration == null || proxyConfiguration.authentication() == ProxyAuthenticationType.NONE) {
                             proxyState = ProxyState.PN_PROXY_CONNECTED;
                         } else {
                             if (LOGGER.isErrorEnabled()) {
                                 LOGGER.error("ProxyConfiguration mismatch. User configured: '{}', but authentication is not required",
-                                        proxyConfiguration.authentication());
+                                    proxyConfiguration.authentication());
                             }
-
                             closeTailProxyError(PROXY_CONNECT_USER_ERROR);
                         }
                         break;
                     }
 
-                    final String challenge = responseResult.getError();
-                    final Set<ProxyAuthenticationType> supportedTypes = getAuthenticationTypes(challenge);
+                    final Map<String, List<String>> headers = result.getResponse().getHeaders();
+                    final Set<ProxyAuthenticationType> supportedTypes = getAuthenticationTypes(headers);
 
                     // The proxy did not successfully connect, user has specified that they want a particular
                     // authentication method, but it is not in list of supported authentication methods.
                     if (proxyConfiguration != null && !supportedTypes.contains(proxyConfiguration.authentication())) {
                         if (LOGGER.isErrorEnabled()) {
                             LOGGER.error("Proxy authentication required. User configured: '{}', but supported proxy authentication methods are: {}",
-                                    proxyConfiguration.authentication(),
-                                    supportedTypes.stream().map(type -> type.toString()).collect(Collectors.joining(",")));
+                                proxyConfiguration.authentication(),
+                                supportedTypes.stream().map(Enum::toString).collect(Collectors.joining(",")));
                         }
-
-                        closeTailProxyError(PROXY_CONNECT_USER_ERROR + PROXY_CONNECT_FAILED + challenge);
+                        closeTailProxyError(PROXY_CONNECT_USER_ERROR + PROXY_CONNECT_FAILED
+                                + result.getResponse().toString());
                         break;
                     }
 
+                    final List<String> challenges = headers.getOrDefault(PROXY_AUTHENTICATE, new ArrayList<>());
                     final ProxyChallengeProcessor processor = proxyConfiguration != null
-                            ? getChallengeProcessor(host, challenge, proxyConfiguration.authentication())
-                            : getChallengeProcessor(host, challenge, supportedTypes);
+                            ? getChallengeProcessor(host, challenges, proxyConfiguration.authentication())
+                            : getChallengeProcessor(host, challenges, supportedTypes);
 
                     if (processor != null) {
                         proxyState = ProxyState.PN_PROXY_CHALLENGE;
-                        headers = processor.getHeader();
+                        ProxyImpl.this.headers = processor.getHeader();
                     } else {
-                        closeTailProxyError(PROXY_CONNECT_FAILED + challenge);
+                        LOGGER.warn("Could not get ProxyChallengeProcessor for challenges.");
+                        closeTailProxyError(PROXY_CONNECT_FAILED + String.join(";", challenges));
                     }
                     break;
                 case PN_PROXY_CHALLENGE_RESPONDED:
                     inputBuffer.flip();
-                    final ProxyHandler.ProxyResponseResult result = proxyHandler.validateProxyResponse(inputBuffer);
-                    inputBuffer.compact();
+                    final ProxyResponse response = readProxyResponse(inputBuffer);
 
-                    if (result.getIsSuccess()) {
+                    if (response != null && response.isMissingContent()) {
+                        LOGGER.warn("Request is missing content. Waiting for more bytes.");
+                        break;
+                    }
+
+                    final ProxyResponseResult challengeResult = proxyHandler.validateProxyResponse(response);
+
+                    if (challengeResult.isSuccess()) {
                         proxyState = ProxyState.PN_PROXY_CONNECTED;
                     } else {
-                        closeTailProxyError(PROXY_CONNECT_FAILED + result.getError());
+                        closeTailProxyError(PROXY_CONNECT_FAILED + challengeResult.getResponse());
                     }
                     break;
                 default:
@@ -353,6 +379,11 @@ public class ProxyImpl implements Proxy, TransportLayer {
             }
         }
 
+        /**
+         * Gets the beginning of the output buffer.
+         *
+         * @return The beginning of the byte buffer.
+         */
         @Override
         public ByteBuffer head() {
             if (getIsHandshakeInProgress()) {
@@ -368,6 +399,11 @@ public class ProxyImpl implements Proxy, TransportLayer {
             }
         }
 
+        /**
+         * Removes the first number of bytes from the output buffer.
+         *
+         * @param bytes The number of bytes to remove from the output buffer.
+         */
         @Override
         public void pop(int bytes) {
             if (getIsHandshakeInProgress()) {
@@ -392,6 +428,9 @@ public class ProxyImpl implements Proxy, TransportLayer {
             }
         }
 
+        /**
+         * Closes the output transport.
+         */
         @Override
         public void close_head() {
             headClosed = true;
@@ -402,18 +441,21 @@ public class ProxyImpl implements Proxy, TransportLayer {
          * Gets the ProxyChallengeProcessor based on authentication types supported. Prefers DIGEST authentication if
          * supported over BASIC. Returns null if it cannot match any supported types.
          */
-        private ProxyChallengeProcessor getChallengeProcessor(String host, String challenge,
+        private ProxyChallengeProcessor getChallengeProcessor(String host, List<String> challenges,
                                                               Set<ProxyAuthenticationType> authentication) {
+            final ProxyAuthenticationType authType;
             if (authentication.contains(DIGEST)) {
-                return getChallengeProcessor(host, challenge, DIGEST);
+                authType = DIGEST;
             } else if (authentication.contains(BASIC)) {
-                return getChallengeProcessor(host, challenge, BASIC);
+                authType = BASIC;
             } else {
                 return null;
             }
+
+            return getChallengeProcessor(host, challenges, authType);
         }
 
-        private ProxyChallengeProcessor getChallengeProcessor(String host, String challenge,
+        private ProxyChallengeProcessor getChallengeProcessor(String host, List<String> challenges,
                                                               ProxyAuthenticationType authentication) {
             final ProxyAuthenticator authenticator = proxyConfiguration != null
                     ? new ProxyAuthenticator(proxyConfiguration)
@@ -421,47 +463,45 @@ public class ProxyImpl implements Proxy, TransportLayer {
 
             switch (authentication) {
                 case DIGEST:
-                    return new DigestProxyChallengeProcessorImpl(host, challenge, authenticator);
+                    final Optional<String> matching = challenges.stream()
+                            .filter(challenge -> challenge.toLowerCase(Locale.ROOT).startsWith(Constants.DIGEST_LOWERCASE))
+                            .findFirst();
+
+                    return matching.map(c -> new DigestProxyChallengeProcessorImpl(host, c, authenticator))
+                            .orElse(null);
                 case BASIC:
                     return new BasicProxyChallengeProcessorImpl(host, authenticator);
                 default:
+                    LOGGER.warn("Authentication type does not have a challenge processor: {}", authentication);
                     return null;
             }
         }
 
         /**
-         * Gets the supported authentication types based on the {@code error}.
+         * Gets the supported authentication types based on the {@code headers}.
          *
-         * @param error Response from service call.
-         * @return The supported proxy authentication methods. Or, an empty array if the value of {@code error} is
-         *     {@code null}, an empty string. Also, if it does not contain {@link Constants#PROXY_AUTHENTICATE_HEADER} with
-         *     {@link Constants#BASIC_LOWERCASE} or {@link Constants#DIGEST_LOWERCASE}.
+         * @param headers HTTP proxy response headers from service call.
+         * @return The supported proxy authentication methods. Or, an empty set if the value of {@code error} is {@code
+         *         null}, an empty string. Or, if it does not contain{@link Constants#PROXY_AUTHENTICATE_HEADER} with
+         *         {@link Constants#BASIC_LOWERCASE} or {@link Constants#DIGEST_LOWERCASE}.
          */
-        private Set<ProxyAuthenticationType> getAuthenticationTypes(String error) {
-            int index = error.indexOf(Constants.PROXY_AUTHENTICATE_HEADER);
-
-            if (index == -1) {
+        private Set<ProxyAuthenticationType> getAuthenticationTypes(Map<String, List<String>> headers) {
+            if (!headers.containsKey(PROXY_AUTHENTICATE)) {
                 return Collections.emptySet();
             }
 
-            Set<ProxyAuthenticationType> supportedTypes = new HashSet<>();
+            final Set<ProxyAuthenticationType> supportedTypes = new HashSet<>();
+            final List<String> authenticationTypes = headers.get(PROXY_AUTHENTICATE);
 
-            try (Scanner scanner = new Scanner(error)) {
-                while (scanner.hasNextLine()) {
-                    String line = scanner.nextLine().trim();
+            for (String type : authenticationTypes) {
+                final String lowercase = type.toLowerCase(Locale.ROOT);
 
-                    if (!line.startsWith(Constants.PROXY_AUTHENTICATE_HEADER)) {
-                        continue;
-                    }
-
-                    String substring = line.substring(Constants.PROXY_AUTHENTICATE_HEADER.length())
-                            .trim().toLowerCase(Locale.ROOT);
-
-                    if (substring.startsWith(Constants.BASIC_LOWERCASE)) {
-                        supportedTypes.add(BASIC);
-                    } else if (substring.startsWith(Constants.DIGEST_LOWERCASE)) {
-                        supportedTypes.add(DIGEST);
-                    }
+                if (lowercase.startsWith(Constants.BASIC_LOWERCASE)) {
+                    supportedTypes.add(BASIC);
+                } else if (lowercase.startsWith(Constants.DIGEST_LOWERCASE)) {
+                    supportedTypes.add(DIGEST);
+                } else {
+                    LOGGER.warn("Did not understand this authentication type: {}", type);
                 }
             }
 
@@ -471,6 +511,32 @@ public class ProxyImpl implements Proxy, TransportLayer {
         private void closeTailProxyError(String errorMessage) {
             tailClosed = true;
             underlyingTransport.closed(new TransportException(errorMessage));
+        }
+
+        /**
+         * Given a byte buffer, reads a HTTP proxy response from it.
+         *
+         * @param buffer The buffer to read HTTP proxy response from.
+         * @return The current HTTP proxy response. Or {@code null} if one could not be read from the buffer and there
+         *         is no current HTTP response.
+         */
+        private ProxyResponse readProxyResponse(ByteBuffer buffer) {
+            int size = buffer.remaining();
+            if (size <= 0) {
+                LOGGER.warn("InputBuffer is empty. Not reading any contents from it. Returning current response.");
+                return proxyAuthResponse.get();
+            }
+
+            ProxyResponse current = proxyAuthResponse.get();
+            if (current == null) {
+                proxyAuthResponse.set(ProxyResponseImpl.create(buffer));
+            } else {
+                current.addContent(buffer);
+            }
+
+            buffer.compact();
+
+            return proxyAuthResponse.get();
         }
     }
 }

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -278,7 +278,7 @@ public class ProxyImpl implements Proxy, TransportLayer {
                         if (LOGGER.isErrorEnabled()) {
                             LOGGER.error("Proxy authentication required. User configured: '{}', but supported proxy authentication methods are: {}",
                                 proxyConfiguration.authentication(),
-                                supportedTypes.stream().map(Enum::toString).collect(Collectors.joining(",")));
+                                supportedTypes.stream().map(type -> type.toString()).collect(Collectors.joining(",")));
                         }
                         closeTailProxyError(PROXY_CONNECT_USER_ERROR + PROXY_CONNECT_FAILED
                                 + result.getResponse().toString());

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -34,6 +34,9 @@ import java.util.stream.Collectors;
 import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.BASIC;
 import static com.microsoft.azure.proton.transport.proxy.ProxyAuthenticationType.DIGEST;
 import static com.microsoft.azure.proton.transport.proxy.impl.Constants.PROXY_AUTHENTICATE;
+import static com.microsoft.azure.proton.transport.proxy.impl.Constants.PROXY_CONNECT_FAILED;
+import static com.microsoft.azure.proton.transport.proxy.impl.Constants.PROXY_CONNECT_USER_ERROR;
+import static com.microsoft.azure.proton.transport.proxy.impl.Constants.PROXY_HANDSHAKE_BUFFER_SIZE;
 import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newWriteableBuffer;
 
 /**
@@ -45,9 +48,6 @@ import static org.apache.qpid.proton.engine.impl.ByteBufferUtils.newWriteableBuf
  */
 public class ProxyImpl implements Proxy, TransportLayer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyImpl.class);
-    private static final String PROXY_CONNECT_FAILED = "Proxy connect request failed with error: ";
-    private static final String PROXY_CONNECT_USER_ERROR = "User configuration error. Using non-matching proxy authentication.";
-    private static final int PROXY_HANDSHAKE_BUFFER_SIZE = 8 * 1024; // buffers used only for proxy-handshake
 
     private final ByteBuffer inputBuffer;
     private final ByteBuffer outputBuffer;
@@ -246,7 +246,7 @@ public class ProxyImpl implements Proxy, TransportLayer {
                     final ProxyResponse connectResponse = readProxyResponse(inputBuffer);
 
                     if (connectResponse == null || connectResponse.isMissingContent()) {
-                        LOGGER.warn("Request is missing content. Waiting for more bytes.");
+                        LOGGER.info("Request is missing content. Waiting for more bytes.");
                         break;
                     }
                     //Clean up response to prepare for challenge

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImpl.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.proton.transport.proxy.impl;
+
+import com.microsoft.azure.proton.transport.proxy.HttpStatusLine;
+import com.microsoft.azure.proton.transport.proxy.ProxyResponse;
+import com.microsoft.azure.proton.transport.ws.WebSocket.WebSocketFrameReadState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Represents an HTTP response from a proxy.
+ *
+ * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html">RFC2616</a>
+ */
+public class ProxyResponseImpl implements ProxyResponse {
+    private static final String CONTENT_LENGTH = "Content-Length";
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyResponseImpl.class);
+
+    private final HttpStatusLine status;
+    private final Map<String, List<String>> headers;
+    private ByteBuffer contents;
+    private WebSocketFrameReadState frameReadState;
+
+    private ProxyResponseImpl(HttpStatusLine status, Map<String, List<String>> headers, ByteBuffer contents,
+                              WebSocketFrameReadState frameReadState) {
+        this.status = status;
+        this.headers = headers;
+        this.contents = contents;
+        this.frameReadState = frameReadState;
+    }
+
+    static ProxyResponse create(ByteBuffer buffer) {
+        // Because we've flipped the buffer, position = 0, and the limit = size of the content.
+        int size = buffer.remaining();
+
+        if (size <= 0) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT,
+                    "Cannot create a buffer with no items in it. Limit: %s. Position: %s. Cap: %s",
+                    buffer.limit(), buffer.position(), buffer.capacity()));
+        }
+
+        final byte[] responseBytes = new byte[size];
+        buffer.get(responseBytes);
+
+        final String response = new String(responseBytes, StandardCharsets.UTF_8);
+        final String[] lines = response.split(StringUtils.NEW_LINE);
+        final Map<String, List<String>> headers = new HashMap<>();
+
+        WebSocketFrameReadState frameReadState = WebSocketFrameReadState.INIT_READ;
+        HttpStatusLine statusLine = null;
+        ByteBuffer contents = ByteBuffer.allocate(0);
+
+        for (String line : lines) {
+            switch (frameReadState) {
+                case INIT_READ:
+                    statusLine = HttpStatusLine.create(line);
+                    frameReadState = WebSocketFrameReadState.CHUNK_READ;
+                    break;
+                case CHUNK_READ:
+                    if (StringUtils.isNullOrEmpty(line)) {
+                        // Now that we're done reading all the headers, figure out the size of the HTTP body and
+                        // allocate an array of that size.
+                        int length = 0;
+                        if (headers.containsKey(CONTENT_LENGTH)) {
+                            final List<String> contentLength = headers.get(CONTENT_LENGTH);
+                            length = Integer.parseInt(contentLength.get(0));
+                        }
+
+                        boolean hasBody = length > 0;
+                        if (!hasBody) {
+                            LOGGER.info("There is no content in the response. Response: {}", response);
+                            return new ProxyResponseImpl(statusLine, headers, contents, WebSocketFrameReadState.INIT_READ);
+                        }
+
+                        contents = ByteBuffer.allocate(length);
+                        frameReadState = WebSocketFrameReadState.HEADER_READ;
+                    } else {
+                        final Map.Entry<String, String> header = parseHeader(line);
+                        final List<String> value = headers.getOrDefault(header.getKey(), new ArrayList<>());
+
+                        value.add(header.getValue());
+                        headers.put(header.getKey(), value);
+                    }
+                    break;
+                case HEADER_READ:
+                    if (contents.position() == 0) {
+                        frameReadState = WebSocketFrameReadState.CONTINUED_FRAME_READ;
+                    }
+
+                    contents.put(line.getBytes(StandardCharsets.UTF_8));
+                    contents.mark();
+                    break;
+                case CONTINUED_FRAME_READ:
+                    contents.put(line.getBytes(StandardCharsets.UTF_8));
+                    contents.mark();
+                    break;
+                default:
+                    LOGGER.error("Unknown state: {}. Response: {}", frameReadState, response);
+                    frameReadState = WebSocketFrameReadState.READ_ERROR;
+                    break;
+            }
+        }
+
+        frameReadState = contents.hasRemaining()
+                ? WebSocketFrameReadState.CONTINUED_FRAME_READ
+                : WebSocketFrameReadState.INIT_READ;
+
+        return new ProxyResponseImpl(statusLine, headers, contents, frameReadState);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public HttpStatusLine getStatus() {
+        return status;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public ByteBuffer getContents() {
+        return contents.duplicate();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getError() {
+        final ByteBuffer readonly = contents.asReadOnlyBuffer();
+        readonly.flip();
+        return StandardCharsets.UTF_8.decode(readonly).toString();
+    }
+
+    /**
+     * Gets whether or not the HTTP response is complete. An HTTP response is complete when the HTTP header and body are
+     * received.
+     *
+     * @return {@code true} if the HTTP response is complete, and {@code false} otherwise.
+     */
+    public boolean isMissingContent() {
+        return contents.hasRemaining();
+    }
+
+    /**
+     * Adds additional content to the HTTP response's body. Assumes that the {@code content} has been flipped.
+     *
+     * @param content Content to add to the body of the HTTP response.
+     */
+    public void addContent(ByteBuffer content) {
+        int size = content.remaining();
+
+        if (size <= 0) {
+            LOGGER.warn("There was no content to add to current HTTP response.");
+            return;
+        }
+
+        final byte[] responseBytes = new byte[content.remaining()];
+        content.get(responseBytes);
+
+        this.contents.put(responseBytes);
+    }
+
+    private static Map.Entry<String, String> parseHeader(String contents) {
+        final String[] split = contents.split(":", 2);
+
+        if (split.length != 2) {
+            throw new IllegalStateException("Line is not a valid header. Contents: " + contents);
+        }
+
+        return new AbstractMap.SimpleEntry<>(split[0].trim(), split[1].trim());
+    }
+}

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImpl.java
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) Microsoft. All rights reserved.
- * Licensed under the MIT license. See LICENSE file in the project root for full license information.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 package com.microsoft.azure.proton.transport.proxy.impl;
 
@@ -17,7 +15,6 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -25,7 +22,7 @@ import java.util.Map;
  *
  * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html">RFC2616</a>
  */
-public class ProxyResponseImpl implements ProxyResponse {
+public final class ProxyResponseImpl implements ProxyResponse {
     private static final String CONTENT_LENGTH = "Content-Length";
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyResponseImpl.class);
 
@@ -47,9 +44,9 @@ public class ProxyResponseImpl implements ProxyResponse {
         int size = buffer.remaining();
 
         if (size <= 0) {
-            throw new IllegalArgumentException(String.format(Locale.ROOT,
-                    "Cannot create a buffer with no items in it. Limit: %s. Position: %s. Cap: %s",
-                    buffer.limit(), buffer.position(), buffer.capacity()));
+            LOGGER.warn("Cannot create a buffer with no items in it. Limit: {}. Position: {}. Cap: {}",
+                    buffer.limit(), buffer.position(), buffer.capacity());
+            return null;
         }
 
         final byte[] responseBytes = new byte[size];

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/StringUtils.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/StringUtils.java
@@ -7,6 +7,8 @@ package com.microsoft.azure.proton.transport.proxy.impl;
  * Utility classes for strings.
  */
 class StringUtils {
+    static final String NEW_LINE = "\r\n";
+
     static boolean isNullOrEmpty(String string) {
         return string == null || string.isEmpty();
     }

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/DigestProxyChallengeProcessorImplTest.java
@@ -180,10 +180,10 @@ public class DigestProxyChallengeProcessorImplTest {
     }
 
     private static String generateProxyChallenge(String realm, String nonce, String qop) {
-        final String digest = String.format("%s %s realm=\"%s\", nonce=\"%s\", qop=\"%s\", stale=false",
-                Constants.PROXY_AUTHENTICATE_HEADER, Constants.DIGEST, realm, nonce, qop);
-        final String basic = String.format("%s %s realm=\"%s\"",
-                Constants.PROXY_AUTHENTICATE_HEADER, Constants.BASIC, realm);
+        final String digest = String.format("%s realm=\"%s\", nonce=\"%s\", qop=\"%s\", stale=false",
+                Constants.DIGEST, realm, nonce, qop);
+        final String basic = String.format("%s realm=\"%s\"",
+                Constants.BASIC, realm);
 
         return String.join(NEW_LINE,
                 "HTTP/1.1 407 Proxy Authentication Required",

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/HTTPStatusLineTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/HTTPStatusLineTest.java
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.azure.proton.transport.proxy.impl;
+
+import com.microsoft.azure.proton.transport.proxy.HttpStatusLine;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class HTTPStatusLineTest {
+
+    /**
+     * Verifies that it successfully parses a valid HTTP status line.
+     */
+    @Test
+    public void validStatusLine() {
+        // Arrange
+        final String line = "HTTP/1.1 200 Connection Established";
+
+        // Act
+        final HttpStatusLine actual = HttpStatusLine.create(line);
+
+        // Assert
+        Assert.assertNotNull(actual);
+
+        Assert.assertEquals(200, actual.getStatusCode());
+        Assert.assertEquals("1.1", actual.getProtocolVersion());
+        Assert.assertEquals("Connection Established", actual.getReason());
+    }
+
+
+    /**
+     * Verifies that status line length is invalid
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"HTTP/1.1 InvalidLength", "HTTP/1.1 Invalid Code", "HTTP/invalid protocol"})
+    public void invalidStatusLine(String line) {
+
+        // Act & Assert
+        Assert.assertThrows(IllegalArgumentException.class, () -> HttpStatusLine.create(line));
+    }
+
+
+}

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/HttpStatusLineTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/HttpStatusLineTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class HTTPStatusLineTest {
+public class HttpStatusLineTest {
 
     /**
      * Verifies that it successfully parses a valid HTTP status line.

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
@@ -7,8 +7,6 @@ import com.microsoft.azure.proton.transport.proxy.HttpStatusLine;
 import com.microsoft.azure.proton.transport.proxy.ProxyResponse;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -39,9 +37,8 @@ public class ProxyHandlerImplTest {
         Assert.assertEquals(expectedProxyRequest, actualProxyRequest);
     }
 
-    @ParameterizedTest
-    @ValueSource(ints = {200, 201, 202, 203, 204, 205, 206})
-    public void testValidateProxyResponseOnSuccess(int httpCode) {
+    @Test
+    public void testValidateProxyResponseOnSuccess() {
         // Arrange
         final HttpStatusLine statusLine = HttpStatusLine.create("HTTP/1.1 200 Connection Established");
         final ProxyResponse response = mock(ProxyResponse.class);

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
@@ -4,7 +4,6 @@
 package com.microsoft.azure.proton.transport.proxy.impl;
 
 import com.microsoft.azure.proton.transport.proxy.HttpStatusLine;
-import com.microsoft.azure.proton.transport.proxy.ProxyHandler;
 import com.microsoft.azure.proton.transport.proxy.ProxyResponse;
 import org.junit.Assert;
 import org.junit.Test;
@@ -51,12 +50,11 @@ public class ProxyHandlerImplTest {
         final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
 
         // Act
-        final ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(response);
+        final boolean result = proxyHandler.validateProxyResponse(response);
 
         // Assert
-        Assert.assertTrue(responseResult.isSuccess());
-        Assert.assertSame(response, responseResult.getResponse());
-        Assert.assertNull(responseResult.getError());
+        Assert.assertTrue(result);
+
     }
 
     @Test
@@ -74,11 +72,10 @@ public class ProxyHandlerImplTest {
         final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
 
         // Act
-        final ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(response);
+        final boolean result = proxyHandler.validateProxyResponse(response);
 
         // Assert
-        Assert.assertFalse(responseResult.isSuccess());
-        Assert.assertEquals(contents, responseResult.getError());
+        Assert.assertFalse(result);
     }
 
     @Test
@@ -97,11 +94,9 @@ public class ProxyHandlerImplTest {
         final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
 
         // Act
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(response);
+        final boolean result = proxyHandler.validateProxyResponse(response);
 
         // Assert
-        Assert.assertFalse(responseResult.isSuccess());
-        Assert.assertEquals(emptyResponse, responseResult.getError());
-        Assert.assertSame(buffer, response.getContents());
+        Assert.assertFalse(result);
     }
 }

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
@@ -42,6 +42,7 @@ public class ProxyHandlerImplTest {
 
     @ParameterizedTest
     @ValueSource(ints = {200, 201, 202, 203, 204, 205, 206})
+    public void testValidateProxyResponseOnSuccess(int httpCode) {
         // Arrange
         final HttpStatusLine statusLine = HttpStatusLine.create("HTTP/1.1 200 Connection Established");
         final ProxyResponse response = mock(ProxyResponse.class);
@@ -103,5 +104,4 @@ public class ProxyHandlerImplTest {
         Assert.assertEquals(emptyResponse, responseResult.getError());
         Assert.assertSame(buffer, response.getContents());
     }
-
 }

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyHandlerImplTest.java
@@ -3,15 +3,21 @@
 
 package com.microsoft.azure.proton.transport.proxy.impl;
 
+import com.microsoft.azure.proton.transport.proxy.HttpStatusLine;
 import com.microsoft.azure.proton.transport.proxy.ProxyHandler;
+import com.microsoft.azure.proton.transport.proxy.ProxyResponse;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+
+import static com.microsoft.azure.proton.transport.proxy.impl.StringUtils.NEW_LINE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ProxyHandlerImplTest {
     @Test
@@ -36,77 +42,66 @@ public class ProxyHandlerImplTest {
 
     @ParameterizedTest
     @ValueSource(ints = {200, 201, 202, 203, 204, 205, 206})
-    public void testValidateProxyResponseOnSuccess(int httpCode) {
-        final String validResponse = "HTTP/1.1 " + httpCode + "Connection Established\r\n"
-            + "FiddlerGateway: Direct\r\n"
-            + "StartTime: 13:08:21.574\r\n"
-            + "Connection: close";
-        final ByteBuffer buffer = ByteBuffer.allocate(1024);
-        buffer.put(validResponse.getBytes(StandardCharsets.UTF_8));
-        buffer.flip();
-
+        // Arrange
+        final HttpStatusLine statusLine = HttpStatusLine.create("HTTP/1.1 200 Connection Established");
+        final ProxyResponse response = mock(ProxyResponse.class);
+        when(response.isMissingContent()).thenReturn(false);
+        when(response.getStatus()).thenReturn(statusLine);
         final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
 
-        Assert.assertTrue(responseResult.getIsSuccess());
+        // Act
+        final ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(response);
+
+        // Assert
+        Assert.assertTrue(responseResult.isSuccess());
+        Assert.assertSame(response, responseResult.getResponse());
         Assert.assertNull(responseResult.getError());
-
-        Assert.assertEquals(0, buffer.remaining());
     }
 
     @Test
     public void testValidateProxyResponseOnFailure() {
-        final String failResponse = String.join("\r\n", "HTTP/1.1 407 Proxy Auth Required",
-            "Connection: close",
-            "Proxy-Authenticate: Basic realm=\\\"FiddlerProxy (user: 1, pass: 1)\\",
-            "Content-Type: text/html",
-            "<html><body>[Fiddler] Proxy Authentication Required.<BR></body></html>\r\n");
-        final ByteBuffer buffer = ByteBuffer.allocate(1024);
-        buffer.put(failResponse.getBytes(StandardCharsets.UTF_8));
-        buffer.flip();
+        // Arrange
+        final HttpStatusLine statusLine = HttpStatusLine.create("HTTP/1.1 407 Proxy Auth Required");
+        final String contents = "<html><body>[Fiddler] Proxy Authentication Required.<BR></body></html>";
+        final ByteBuffer encoded = UTF_8.encode(contents);
+        final ProxyResponse response = mock(ProxyResponse.class);
+        when(response.isMissingContent()).thenReturn(false);
+        when(response.getStatus()).thenReturn(statusLine);
+        when(response.getContents()).thenReturn(encoded);
+        when(response.getError()).thenReturn(contents);
 
         final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
 
-        Assert.assertTrue(!responseResult.getIsSuccess());
-        Assert.assertEquals(failResponse, responseResult.getError());
+        // Act
+        final ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(response);
 
-        Assert.assertEquals(0, buffer.remaining());
-    }
-
-    @Test
-    public void testValidateProxyResponseOnInvalidResponse() {
-        final String invalidResponse = String.join("\r\n", "HTTP/1.1 abc Connection Established",
-            "HTTP/1.1 200 Connection Established",
-            "FiddlerGateway: Direct",
-            "StartTime: 13:08:21.574",
-            "Connection: close\r\n");
-        final ByteBuffer buffer = ByteBuffer.allocate(1024);
-        buffer.put(invalidResponse.getBytes(StandardCharsets.UTF_8));
-        buffer.flip();
-
-        final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
-
-        Assert.assertTrue(!responseResult.getIsSuccess());
-        Assert.assertEquals(invalidResponse, responseResult.getError());
-
-        Assert.assertEquals(0, buffer.remaining());
+        // Assert
+        Assert.assertFalse(responseResult.isSuccess());
+        Assert.assertEquals(contents, responseResult.getError());
     }
 
     @Test
     public void testValidateProxyResponseOnEmptyResponse() {
-        final String emptyResponse = "\r\n\r\n";
+        final String emptyResponse = NEW_LINE + NEW_LINE;
         final ByteBuffer buffer = ByteBuffer.allocate(1024);
-        buffer.put(emptyResponse.getBytes(StandardCharsets.UTF_8));
+        buffer.put(emptyResponse.getBytes(UTF_8));
         buffer.flip();
 
+        final ProxyResponse response = mock(ProxyResponse.class);
+        when(response.isMissingContent()).thenReturn(false);
+        when(response.getStatus()).thenReturn(null);
+        when(response.getContents()).thenReturn(buffer);
+        when(response.getError()).thenReturn(emptyResponse);
+
         final ProxyHandlerImpl proxyHandler = new ProxyHandlerImpl();
-        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(buffer);
 
-        Assert.assertTrue(!responseResult.getIsSuccess());
+        // Act
+        ProxyHandler.ProxyResponseResult responseResult = proxyHandler.validateProxyResponse(response);
+
+        // Assert
+        Assert.assertFalse(responseResult.isSuccess());
         Assert.assertEquals(emptyResponse, responseResult.getError());
-
-        Assert.assertEquals(0, buffer.remaining());
+        Assert.assertSame(buffer, response.getContents());
     }
+
 }

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImplTest.java
@@ -330,7 +330,7 @@ public class ProxyImplTest {
 
         when(mockHandler.createProxyRequest(any(), any())).thenReturn("proxy request");
 
-        when(mockResponse.getIsSuccess()).thenReturn(true);
+        when(mockResponse.isSuccess()).thenReturn(true);
         when(mockResponse.getError()).thenReturn(null);
         when(mockHandler.validateProxyResponse(any())).thenReturn(mockResponse);
 
@@ -355,7 +355,7 @@ public class ProxyImplTest {
 
         when(mockHandler.createProxyRequest(any(), any())).thenReturn("proxy request");
 
-        when(mockResponse.getIsSuccess()).thenReturn(false);
+        when(mockResponse.isSuccess()).thenReturn(false);
         when(mockResponse.getError()).thenReturn("proxy failure response");
         when(mockHandler.validateProxyResponse(any())).thenReturn(mockResponse);
 
@@ -684,7 +684,7 @@ public class ProxyImplTest {
         when(handler.createProxyRequest(any(), any())).thenReturn("proxy request");
         when(handler.validateProxyResponse(any())).thenReturn(mockResponse);
 
-        when(mockResponse.getIsSuccess()).thenReturn(false);
+        when(mockResponse.isSuccess()).thenReturn(false);
         when(mockResponse.getError()).thenReturn(getProxyChallenge(true, false));
 
         // Act and Assert
@@ -718,7 +718,7 @@ public class ProxyImplTest {
         when(handler.createProxyRequest(any(), any())).thenReturn("proxy request");
         when(handler.validateProxyResponse(any())).thenReturn(mockResponse);
 
-        when(mockResponse.getIsSuccess()).thenReturn(true);
+        when(mockResponse.isSuccess()).thenReturn(true);
         when(mockResponse.getError()).thenReturn(null);
 
         // Act and Assert
@@ -752,7 +752,7 @@ public class ProxyImplTest {
         when(handler.createProxyRequest(any(), any())).thenReturn("proxy request", "proxy request2");
         when(handler.validateProxyResponse(any())).thenReturn(mockResponse);
 
-        when(mockResponse.getIsSuccess()).thenReturn(false, true);
+        when(mockResponse.isSuccess()).thenReturn(false, true);
         when(mockResponse.getError()).thenReturn(getProxyChallenge(true, true), "Success.");
 
         // Act and Assert
@@ -814,7 +814,7 @@ public class ProxyImplTest {
         when(handler.createProxyRequest(any(), any())).thenReturn("proxy request", "proxy request2");
         when(handler.validateProxyResponse(any())).thenReturn(mockResponse);
 
-        when(mockResponse.getIsSuccess()).thenReturn(false, true);
+        when(mockResponse.isSuccess()).thenReturn(false, true);
         when(mockResponse.getError()).thenReturn(getProxyChallenge(true, true), "Success.");
 
         // Act and Assert

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImplTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.proton.transport.proxy.impl;
+
+import com.microsoft.azure.proton.transport.proxy.HttpStatusLine;
+import com.microsoft.azure.proton.transport.proxy.ProxyResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.microsoft.azure.proton.transport.proxy.impl.StringUtils.NEW_LINE;
+
+public class ProxyResponseImplTest {
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String CONTENT_TYPE_TEXT = "text/plain";
+    private static final String CONTENT_LENGTH = "Content-Length";
+    private static final Charset ENCODING = StandardCharsets.UTF_8;
+    private static final String HEADER_FORMAT = "%s: %s" + NEW_LINE;
+
+    /**
+     * Verifies that it successfully parses a valid HTTP response.
+     */
+    @Test
+    public void validResponse() {
+        // Arrange
+        final String[] statusLine = new String[]{"HTTP/1.1", "200", "Connection Established"};
+        final Map<String, String> headers = new HashMap<>();
+        headers.put("FiddlerGateway", "Direct");
+        headers.put("StartTime", "13:08:21.574");
+        headers.put("Connection", "close");
+
+        final String response = getTestResponse(statusLine, headers);
+        final ByteBuffer contents = ENCODING.encode(response);
+
+        // Act
+        final ProxyResponse actual = ProxyResponseImpl.create(contents);
+
+        // Assert
+        final HttpStatusLine status = actual.getStatus();
+        Assert.assertEquals("1.1", status.getProtocolVersion());
+        Assert.assertEquals(statusLine[2], status.getReason());
+        Assert.assertEquals(Integer.parseInt(statusLine[1]), status.getStatusCode());
+
+        Assert.assertFalse(actual.isMissingContent());
+
+        final Map<String, List<String>> actualHeaders = actual.getHeaders();
+        Assert.assertEquals(headers.size(), actualHeaders.size());
+
+        headers.forEach((key, value) -> {
+            final List<String> actualValue = actualHeaders.get(key);
+
+            Assert.assertTrue(actualHeaders.containsKey(key));
+            Assert.assertNotNull(actualValue);
+            Assert.assertEquals(1, actualValue.size());
+            Assert.assertEquals(value, actualValue.get(0));
+        });
+    }
+
+    /**
+     * Verifies that an exception is thrown when the header is invalid. successfully parses a valid HTTP response.
+     */
+    @Test
+    public void invalidHeader() {
+        // Arrange
+        final String[] statusLine = new String[]{"HTTP/1.1", "abc", "Connection Established"};
+        final Map<String, String> headers = new HashMap<>();
+        headers.put("FiddlerGateway", "Direct");
+        headers.put("StartTime", "13:08:21.574");
+        headers.put("Connection", "close");
+
+        final String response = getTestResponse(statusLine, headers);
+        final ByteBuffer contents = ENCODING.encode(response);
+
+        // Act & Assert
+        try {
+            ProxyResponseImpl.create(contents);
+        } catch (IllegalArgumentException e) {
+            Assert.assertNotNull(e.getCause());
+            Assert.assertEquals(NumberFormatException.class, e.getCause().getClass());
+        }
+    }
+
+    /**
+     * Verifies that we can parse an empty response.
+     */
+    @Test
+    public void emptyResponse() {
+        // Arrange
+        final String emptyResponse = NEW_LINE + NEW_LINE;
+        final ByteBuffer buffer = ByteBuffer.allocate(1024);
+        buffer.put(emptyResponse.getBytes(ENCODING));
+        buffer.flip();
+
+        // Act
+        final ProxyResponse response = ProxyResponseImpl.create(buffer);
+
+        // Assert
+        Assert.assertNull(response.getStatus());
+        Assert.assertFalse(response.isMissingContent());
+        Assert.assertNotNull(response.getHeaders());
+        Assert.assertEquals(0, response.getHeaders().size());
+        Assert.assertEquals(0, response.getContents().position());
+    }
+
+    private static String getTestResponse(String[] statusLine, Map<String, String> headers) {
+        return getTestResponse(statusLine, headers, null);
+    }
+
+    /**
+     * If there is content, {@link #CONTENT_LENGTH} and {@link #CONTENT_TYPE} headers are added to the {@code headers}
+     * parameter.
+     *
+     * @param statusLine HTTP status line to create the proxy response with.
+     * @param headers A set of headers to add to teh proxy response.
+     * @param body Optional HTTP content body.
+     * @return A string representing the contents of the HTTP response.
+     */
+    private static String getTestResponse(String[] statusLine, Map<String, String> headers, String body) {
+        final ByteBuffer encoded;
+        if (body != null) {
+            encoded = ENCODING.encode(body);
+            encoded.flip();
+            final int size = encoded.remaining();
+
+            headers.put(CONTENT_TYPE, CONTENT_TYPE_TEXT);
+            headers.put(CONTENT_LENGTH, Integer.toString(size));
+        }
+
+        final StringBuilder formattedHeaders = headers.entrySet()
+                .stream()
+                .collect(StringBuilder::new,
+                        (builder, entry) -> builder.append(String.format(HEADER_FORMAT, entry.getKey(), entry.getValue())),
+                        StringBuilder::append);
+
+        String response = String.join(NEW_LINE,
+                String.join(" ", statusLine),
+                formattedHeaders.toString(),
+                NEW_LINE); // The empty new line that ends the HTTP headers.
+
+        if (body != null) {
+            response += body + NEW_LINE;
+        }
+
+        return response;
+    }
+}

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImplTest.java
@@ -23,10 +23,10 @@ public class ProxyResponseImplTest {
     public void validResponse() {
         // Arrange
         final String[] statusLine = new String[]{"HTTP/1.1", "200", "Connection Established"};
-        final Map<String, String> headers = new HashMap<>();
-        headers.put("FiddlerGateway", "Direct");
-        headers.put("StartTime", "13:08:21.574");
-        headers.put("Connection", "close");
+        final Map<String, List<String>> headers = new HashMap<>();
+        headers.put("FiddlerGateway", List.of("Direct"));
+        headers.put("StartTime", List.of("13:08:21.574"));
+        headers.put("Connection", List.of("close"));
 
         final String response = TestUtils.createProxyResponse(statusLine, headers);
         final ByteBuffer contents = TestUtils.ENCODING.encode(response);
@@ -53,7 +53,7 @@ public class ProxyResponseImplTest {
             Assert.assertTrue(actualHeaders.containsKey(key));
             Assert.assertNotNull(actualValue);
             Assert.assertEquals(1, actualValue.size());
-            Assert.assertEquals(value, actualValue.get(0));
+            Assert.assertEquals(value.get(0), actualValue.get(0));
         });
     }
 
@@ -64,10 +64,10 @@ public class ProxyResponseImplTest {
     public void invalidHeader() {
         // Arrange
         final String[] statusLine = new String[]{"HTTP/1.1", "abc", "Connection Established"};
-        final Map<String, String> headers = new HashMap<>();
-        headers.put("FiddlerGateway", "Direct");
-        headers.put("StartTime", "13:08:21.574");
-        headers.put("Connection", "close");
+        final Map<String, List<String>> headers = new HashMap<>();
+        headers.put("FiddlerGateway", List.of("Direct"));
+        headers.put("StartTime", List.of("13:08:21.574"));
+        headers.put("Connection", List.of("close"));
 
         final String response = TestUtils.createProxyResponse(statusLine, headers);
         final ByteBuffer contents = TestUtils.ENCODING.encode(response);

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImplTest.java
@@ -59,7 +59,20 @@ public class ProxyResponseImplTest {
     }
 
     /**
-     * Verifies that an exception is thrown when the header is invalid. successfully parses a valid HTTP response.
+     * Verifies that an exception is thrown when buffer is empty
+     */
+    @Test
+    public void invalidBuffer() {
+        // Arrange
+        final ByteBuffer contents = ByteBuffer.allocate(0);
+
+        // Act & Assert
+        Assert.assertThrows(IllegalArgumentException.class, () -> ProxyResponseImpl.create(contents));
+
+    }
+
+    /**
+     * Verifies that an exception is thrown when the header is invalid.
      */
     @Test
     public void invalidHeader() {
@@ -74,12 +87,10 @@ public class ProxyResponseImplTest {
         final ByteBuffer contents = TestUtils.ENCODING.encode(response);
 
         // Act & Assert
-        try {
-            ProxyResponseImpl.create(contents);
-        } catch (IllegalArgumentException e) {
-            Assert.assertNotNull(e.getCause());
-            Assert.assertEquals(NumberFormatException.class, e.getCause().getClass());
-        }
+        IllegalArgumentException thrown = Assert.assertThrows(IllegalArgumentException.class,
+            () -> ProxyResponseImpl.create(contents));
+        Assert.assertEquals(NumberFormatException.class, thrown.getCause().getClass());
+
     }
 
     /**

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImplTest.java
@@ -9,6 +9,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,9 +25,9 @@ public class ProxyResponseImplTest {
         // Arrange
         final String[] statusLine = new String[]{"HTTP/1.1", "200", "Connection Established"};
         final Map<String, List<String>> headers = new HashMap<>();
-        headers.put("FiddlerGateway", List.of("Direct"));
-        headers.put("StartTime", List.of("13:08:21.574"));
-        headers.put("Connection", List.of("close"));
+        headers.put("FiddlerGateway", Collections.singletonList("Direct"));
+        headers.put("StartTime", Collections.singletonList("13:08:21.574"));
+        headers.put("Connection", Collections.singletonList("close"));
 
         final String response = TestUtils.createProxyResponse(statusLine, headers);
         final ByteBuffer contents = TestUtils.ENCODING.encode(response);
@@ -65,9 +66,9 @@ public class ProxyResponseImplTest {
         // Arrange
         final String[] statusLine = new String[]{"HTTP/1.1", "abc", "Connection Established"};
         final Map<String, List<String>> headers = new HashMap<>();
-        headers.put("FiddlerGateway", List.of("Direct"));
-        headers.put("StartTime", List.of("13:08:21.574"));
-        headers.put("Connection", List.of("close"));
+        headers.put("FiddlerGateway", Collections.singletonList("Direct"));
+        headers.put("StartTime", Collections.singletonList("13:08:21.574"));
+        headers.put("Connection", Collections.singletonList("close"));
 
         final String response = TestUtils.createProxyResponse(statusLine, headers);
         final ByteBuffer contents = TestUtils.ENCODING.encode(response);

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyResponseImplTest.java
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) Microsoft. All rights reserved.
- * Licensed under the MIT license. See LICENSE file in the project root for full license information.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 package com.microsoft.azure.proton.transport.proxy.impl;
 

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/TestUtils.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/TestUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.proton.transport.proxy.impl;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static com.microsoft.azure.proton.transport.proxy.impl.StringUtils.NEW_LINE;
+
+class TestUtils {
+    /**
+     * Encoding for the HTTP proxy response.
+     */
+    static final Charset ENCODING = StandardCharsets.UTF_8;
+
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String CONTENT_TYPE_TEXT = "text/plain";
+    private static final String CONTENT_LENGTH = "Content-Length";
+    private static final String HEADER_FORMAT = "%s: %s" + NEW_LINE;
+
+    private TestUtils() {
+    }
+
+    /**
+     * Creates a proxy HTTP response and returns it as a string.
+     *
+     * @param statusLine HTTP status line to create the proxy response with.
+     * @param headers A set of headers to add to the proxy response.
+     * @return A string representing the contents of the HTTP response.
+     */
+    static String createProxyResponse(String[] statusLine, Map<String, String> headers) {
+        return createProxyResponse(statusLine, headers, null);
+    }
+
+    /**
+     * Creates a proxy HTTP response and returns it as a string. If there is content, {@link #CONTENT_LENGTH} and {@link
+     * #CONTENT_TYPE} headers are added to the {@code headers} parameter.
+     *
+     * @param statusLine HTTP status line to create the proxy response with.
+     * @param headers A set of headers to add to the proxy response.
+     * @param body Optional HTTP content body.
+     * @return A string representing the contents of the HTTP response.
+     */
+    static String createProxyResponse(String[] statusLine, Map<String, String> headers, String body) {
+        final ByteBuffer encoded;
+        if (body != null) {
+            encoded = ENCODING.encode(body);
+            encoded.flip();
+            final int size = encoded.remaining();
+
+            headers.put(CONTENT_TYPE, CONTENT_TYPE_TEXT);
+            headers.put(CONTENT_LENGTH, Integer.toString(size));
+        }
+
+        final StringBuilder formattedHeaders = headers.entrySet()
+                .stream()
+                .collect(StringBuilder::new,
+                        (builder, entry) -> builder.append(String.format(HEADER_FORMAT, entry.getKey(), entry.getValue())),
+                        StringBuilder::append);
+
+        String response = String.join(NEW_LINE,
+                String.join(" ", statusLine),
+                formattedHeaders.toString(),
+                NEW_LINE); // The empty new line that ends the HTTP headers.
+
+        if (body != null) {
+            response += body + NEW_LINE;
+        }
+
+        return response;
+    }
+}

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/TestUtils.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/TestUtils.java
@@ -5,6 +5,7 @@ package com.microsoft.azure.proton.transport.proxy.impl;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 
 import static com.microsoft.azure.proton.transport.proxy.impl.StringUtils.NEW_LINE;
@@ -30,7 +31,7 @@ final class TestUtils {
      * @param headers A set of headers to add to the proxy response.
      * @return A string representing the contents of the HTTP response.
      */
-    static String createProxyResponse(String[] statusLine, Map<String, String> headers) {
+    static String createProxyResponse(String[] statusLine, Map<String, List<String>> headers) {
         return createProxyResponse(statusLine, headers, null);
     }
 
@@ -43,21 +44,21 @@ final class TestUtils {
      * @param body Optional HTTP content body.
      * @return A string representing the contents of the HTTP response.
      */
-    static String createProxyResponse(String[] statusLine, Map<String, String> headers, String body) {
+    static String createProxyResponse(String[] statusLine, Map<String, List<String>> headers, String body) {
         final ByteBuffer encoded;
         if (body != null) {
             encoded = ENCODING.encode(body);
             encoded.flip();
             final int size = encoded.remaining();
 
-            headers.put(CONTENT_TYPE, CONTENT_TYPE_TEXT);
-            headers.put(CONTENT_LENGTH, Integer.toString(size));
+            headers.put(CONTENT_TYPE, List.of(CONTENT_TYPE_TEXT));
+            headers.put(CONTENT_LENGTH, List.of(Integer.toString(size)));
         }
 
         final StringBuilder formattedHeaders = headers.entrySet()
                 .stream()
                 .collect(StringBuilder::new,
-                        (builder, entry) -> builder.append(String.format(HEADER_FORMAT, entry.getKey(), entry.getValue())),
+                        (builder, entry) -> entry.getValue().forEach(value -> builder.append(String.format(HEADER_FORMAT, entry.getKey(), value))),
                         StringBuilder::append);
 
         String response = String.join(NEW_LINE,

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/TestUtils.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/TestUtils.java
@@ -1,8 +1,5 @@
-/*
- * Copyright (c) Microsoft. All rights reserved.
- * Licensed under the MIT license. See LICENSE file in the project root for full license information.
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 package com.microsoft.azure.proton.transport.proxy.impl;
 
 import java.nio.ByteBuffer;
@@ -12,7 +9,7 @@ import java.util.Map;
 
 import static com.microsoft.azure.proton.transport.proxy.impl.StringUtils.NEW_LINE;
 
-class TestUtils {
+final class TestUtils {
     /**
      * Encoding for the HTTP proxy response.
      */
@@ -38,8 +35,8 @@ class TestUtils {
     }
 
     /**
-     * Creates a proxy HTTP response and returns it as a string. If there is content, {@link #CONTENT_LENGTH} and {@link
-     * #CONTENT_TYPE} headers are added to the {@code headers} parameter.
+     * Creates a proxy HTTP response and returns it as a string. If there is content, {@link #CONTENT_LENGTH} and
+     * {@link #CONTENT_TYPE} headers are added to the {@code headers} parameter.
      *
      * @param statusLine HTTP status line to create the proxy response with.
      * @param headers A set of headers to add to the proxy response.

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/TestUtils.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/TestUtils.java
@@ -5,6 +5,7 @@ package com.microsoft.azure.proton.transport.proxy.impl;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -51,8 +52,8 @@ final class TestUtils {
             encoded.flip();
             final int size = encoded.remaining();
 
-            headers.put(CONTENT_TYPE, List.of(CONTENT_TYPE_TEXT));
-            headers.put(CONTENT_LENGTH, List.of(Integer.toString(size)));
+            headers.put(CONTENT_TYPE, Collections.singletonList(CONTENT_TYPE_TEXT));
+            headers.put(CONTENT_LENGTH, Collections.singletonList(Integer.toString(size)));
         }
 
         final StringBuilder formattedHeaders = headers.entrySet()

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/TestUtils.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/TestUtils.java
@@ -48,8 +48,10 @@ final class TestUtils {
     static String createProxyResponse(String[] statusLine, Map<String, List<String>> headers, String body) {
         final ByteBuffer encoded;
         if (body != null) {
+            //Add empty line to end body
+            body += NEW_LINE;
+
             encoded = ENCODING.encode(body);
-            encoded.flip();
             final int size = encoded.remaining();
 
             headers.put(CONTENT_TYPE, Collections.singletonList(CONTENT_TYPE_TEXT));
@@ -59,7 +61,8 @@ final class TestUtils {
         final StringBuilder formattedHeaders = headers.entrySet()
                 .stream()
                 .collect(StringBuilder::new,
-                        (builder, entry) -> entry.getValue().forEach(value -> builder.append(String.format(HEADER_FORMAT, entry.getKey(), value))),
+                        (builder, entry) -> entry.getValue()
+                            .forEach(value -> builder.append(String.format(HEADER_FORMAT, entry.getKey(), value))),
                         StringBuilder::append);
 
         String response = String.join(NEW_LINE,
@@ -68,9 +71,10 @@ final class TestUtils {
                 NEW_LINE); // The empty new line that ends the HTTP headers.
 
         if (body != null) {
-            response += body + NEW_LINE;
+            response += body;
         }
 
         return response;
     }
+
 }


### PR DESCRIPTION
Fix [#5124](https://github.com/Azure/azure-sdk-for-java/issues/5124)

### Issue
When using proxy configuration, it is possible that the HTTP response does not come in a single frame, but multiple frames.
This will cause the authorization with the proxy failure with execption. 

### Changes

- Add a new interface `ProxyResponse` and implementation `ProxyResponseImpl` to save multiple frames into one response.
- Add logic to read multiple frames in `ProxyImpl` and update validation logic by getting infomation from `ProxyResponse` header. 
- Remove class `ProxyResponseResult` since all information are already saved in `ProxyResponse`. 
- Update  `DigestProxyChallengeProcessorImpl` authentication logic since now we get types from header rather than error message.
- Reduce buffer size `PROXY_HANDSHAKE_BUFFER_SIZE` from `8 * 1024` to `4 * 1024`.
- Change related UT test. 

### Test scenarios

- [x] BASIC with response over 4K
- [x] Digest with response over 4K
- [x] BASIC with response less 4K 
- [x] Digest with response less 4K 