### PR TITLE
Update dependencies and fix build breaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,20 @@ To build and test this locally, make sure you install:
 Open a command prompt/terminal:
 
 1. Execute `git clone https://github.com/Azure/qpid-proton-j-extensions.git`.
-1. Traverse to the repository root.
-1. Execute `mvn install`.
+2. Traverse to the repository root.
+3. Execute `mvn install`.
 
 This should successfully run all unit/integration tests, build the qpid-proton-j-extensions JAR, and install it to your
 local Maven repository.
+
+### Updating pom.xml dependencies
+
+To update pom.xml dependencies, we leverage the Azure SDKs for Java's update scripts.
+
+1. Install Python 3.
+2. Clone `https://github.com/Azure/azure-sdk-for-java`
+3. From the root of the `azure-sdk-for-java` repository, execute:
+    * `python ./eng/versioning/update_versions.py --ut external_dependency --bt client --tf ${PATH_TO_QPID_PROTON_J_EXTENSIONS_POM.XML}`
 
 ## Filing issues
 

--- a/eng/spotbugs/spotbugs-excludes.xml
+++ b/eng/spotbugs/spotbugs-excludes.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter xmlns="https://github.com/spotbugs/filter/4.8.4"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://github.com/spotbugs/filter/4.8.4 https://raw.githubusercontent.com/spotbugs/spotbugs/4.8.4/spotbugs/etc/findbugsfilter.xsd">
 
-<FindBugsFilter>
   <!-- This was written a while ago and the byte shifts work for outputting the data. -->
   <Match>
     <Class name="com.microsoft.azure.proton.transport.ws.impl.WebSocketHandlerImpl"/>
@@ -34,4 +36,42 @@
     <Method name="writeUpgradeRequest"/>
     <Bug pattern="DM_DEFAULT_ENCODING"/>
   </Match>
+
+  <!-- Proxy is an immutable class. -->
+  <Match>
+    <Class name="com.microsoft.azure.proton.transport.proxy.ProxyConfiguration"/>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+  </Match>
+
+  <Match>
+    <Class name="com.microsoft.azure.proton.transport.proxy.impl.BasicProxyChallengeProcessorImpl"/>
+    <Method name="getHeader" />
+    <Bug pattern="EI_EXPOSE_REP" />
+  </Match>
+
+  <Match>
+    <Class name="com.microsoft.azure.proton.transport.proxy.impl.DigestProxyChallengeProcessorImpl"/>
+    <Method name="getHeader" />
+    <Bug pattern="EI_EXPOSE_REP" />
+  </Match>
+
+  <Match>
+    <Class name="com.microsoft.azure.proton.transport.proxy.impl.ProxyImpl"/>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+  </Match>
+
+  <Match>
+    <Class name="com.microsoft.azure.proton.transport.proxy.impl.ProxyResponseImpl"/>
+    <Or>
+      <Method name="getHeaders" />
+      <Method name="getContents" />
+    </Or>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+
+  <Match>
+    <Class name="com.microsoft.azure.proton.transport.ws.impl.WebSocketImpl"/>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+  </Match>
+
 </FindBugsFilter>

--- a/eng/spotbugs/spotbugs-excludes.xml
+++ b/eng/spotbugs/spotbugs-excludes.xml
@@ -66,7 +66,7 @@
       <Method name="getHeaders" />
       <Method name="getContents" />
     </Or>
-    <Bug pattern="EI_EXPOSE_REP"/>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_BUF"/>
   </Match>
 
   <Match>
@@ -74,4 +74,8 @@
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
   </Match>
 
+  <Match>
+    <Class name="com.microsoft.azure.proton.transport.ws.impl.WebSocketUpgrade"/>
+    <Bug pattern="EI_EXPOSE_REP2" />
+  </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -43,30 +43,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <packageOutputDirectory>${project.build.directory}</packageOutputDirectory>
-
-    <!-- Product dependency versions -->
-    <proton-j-version>0.34.1</proton-j-version>
-    <slf4j-version>1.7.28</slf4j-version>
-
-    <!-- Test dependency versions -->
-    <junit-params-version>5.8.0-M1</junit-params-version>
-    <junit-version>4.13.1</junit-version>
-    <mockito-version>3.0.0</mockito-version>
-
-    <!-- Maven tool versions -->
-    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-    <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
-    <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
-    <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
-    <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-    <maven-spotbugs-plugin.version>4.2.0</maven-spotbugs-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
-
-    <!-- Build tools -->
-    <checkstyle.version>8.42</checkstyle.version>
-    <spotbugs.version>4.2.3</spotbugs.version>
   </properties>
 
   <build>
@@ -75,7 +51,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${maven-checkstyle-plugin.version}</version>
+        <version>3.6.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-checkstyle-plugin;external_dependency} -->
         <executions>
           <execution>
             <phase>verify</phase>
@@ -90,7 +66,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>${maven-spotbugs-plugin.version}</version>
+        <version>4.8.3.1</version> <!-- {x-version-update;com.github.spotbugs:spotbugs-maven-plugin;external_dependency} -->
         <executions>
           <execution>
             <phase>verify</phase>
@@ -105,7 +81,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>${maven-jar-plugin.version}</version>
+        <version>3.4.2</version> <!-- {x-version-update;org.apache.maven.plugins:maven-jar-plugin;external_dependency} -->
         <configuration>
           <archive>
             <manifestEntries>
@@ -120,7 +96,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>${maven-source-plugin.version}</version>
+        <version>3.3.1</version> <!-- {x-version-update;org.apache.maven.plugins:maven-source-plugin;external_dependency} -->
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -138,7 +114,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${maven-javadoc-plugin.version}</version>
+        <version>3.10.1</version> <!-- {x-version-update;org.apache.maven.plugins:maven-javadoc-plugin;external_dependency} -->
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -156,7 +132,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${maven-compiler-plugin.version}</version>
+          <version>3.13.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-compiler-plugin;external_dependency} -->
           <configuration>
             <showWarnings>true</showWarnings>
             <failOnWarning>true</failOnWarning>
@@ -191,18 +167,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>${maven-checkstyle-plugin.version}</version>
+          <version>3.6.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-checkstyle-plugin;external_dependency} -->
           <dependencies>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>${checkstyle.version}</version> <!-- {x-version-update;com.puppycrawl.tools:checkstyle;external_dependency} -->
+              <version>9.3</version> <!-- {x-version-update;com.puppycrawl.tools:checkstyle;external_dependency} -->
             </dependency>
           </dependencies>
           <configuration>
             <configLocation>eng/checkstyle/checkstyle.xml</configLocation>
             <suppressionsLocation>eng/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
-            <encoding>UTF-8</encoding>
             <consoleOutput>true</consoleOutput>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
             <linkXRef>true</linkXRef>
@@ -215,7 +190,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${maven-javadoc-plugin.version}</version>
+          <version>3.10.1</version> <!-- {x-version-update;org.apache.maven.plugins:maven-javadoc-plugin;external_dependency} -->
           <configuration>
             <source>1.8</source>
             <doctitle>Extensions on Apache Proton-J Reference Documentation</doctitle>
@@ -240,7 +215,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${maven-surefire-plugin.version}</version>
+          <version>3.5.2</version> <!-- {x-version-update;org.apache.maven.plugins:maven-surefire-plugin;external_dependency} -->
           <configuration>
             <runOrder>alphabetical</runOrder>
             <useSystemClassLoader>false</useSystemClassLoader>
@@ -253,12 +228,12 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>${maven-spotbugs-plugin.version}</version>
+          <version>4.8.3.1</version> <!-- {x-version-update;com.github.spotbugs:spotbugs-maven-plugin;external_dependency} -->
           <dependencies>
             <dependency>
               <groupId>com.github.spotbugs</groupId>
               <artifactId>spotbugs</artifactId>
-              <version>${spotbugs.version}</version>
+              <version>4.8.3</version> <!-- {x-version-update;com.github.spotbugs:spotbugs;external_dependency} -->
             </dependency>
           </dependencies>
           <configuration>
@@ -277,12 +252,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>${maven-site-plugin.version}</version>
+          <version>3.20.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-site-plugin;external_dependency} -->
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>${maven-project-info-reports-plugin.version}</version>
+          <version>3.8.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-project-info-reports-plugin;external_dependency} -->
         </plugin>
       </plugins>
     </pluginManagement>
@@ -293,14 +268,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${maven-javadoc-plugin.version}</version>
+        <version>3.10.1</version> <!-- {x-version-update;org.apache.maven.plugins:maven-javadoc-plugin;external_dependency} -->
       </plugin>
 
       <!-- This plugin runs spotbugs. -->
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>${maven-spotbugs-plugin.version}</version>
+        <version>4.8.3.1</version> <!-- {x-version-update;com.github.spotbugs:spotbugs-maven-plugin;external_dependency} -->
         <configuration>
           <xmlOutputDirectory>target/site</xmlOutputDirectory>
         </configuration>
@@ -313,43 +288,43 @@
     <dependency>
       <groupId>org.apache.qpid</groupId>
       <artifactId>proton-j</artifactId>
-      <version>${proton-j-version}</version>
+      <version>0.34.1</version> <!-- {x-version-update;org.apache.qpid:proton-j;external_dependency} -->
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j-version}</version>
+      <version>1.7.36</version> <!-- {x-version-update;org.slf4j:slf4j-api;external_dependency} -->
     </dependency>
 
     <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit-version}</version>
+      <version>4.13.2</version> <!-- {x-version-update;junit:junit;external_dependency} -->
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit-params-version}</version>
+      <version>5.11.2</version> <!-- {x-version-update;org.junit.jupiter:junit-jupiter-params;external_dependency} -->
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${mockito-version}</version>
+      <version>4.11.0</version> <!-- {x-version-update;org.mockito:mockito-core;external_dependency} -->
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>${slf4j-version}</version>
+      <version>1.7.36</version> <!-- {x-version-update;org.slf4j:slf4j-simple;external_dependency} -->
       <scope>test</scope>
     </dependency>
   </dependencies>
 
   <profiles>
-    <!-- By default we build against our baseline, Java 11, but we also want to ensure compatibility against the latest
+    <!-- By default, we build against our baseline, Java 11, but we also want to ensure compatibility against the latest
         Java 8 LTS release. The default 'java11', which will perform a build using Java 11 as its target. -->
     <profile>
       <id>java8</id>
@@ -366,7 +341,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>${maven-compiler-plugin.version}</version>
+            <version>3.13.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-compiler-plugin;external_dependency} -->
             <configuration>
               <source>1.8</source>
               <target>1.8</target>
@@ -380,7 +355,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>${maven-javadoc-plugin.version}</version>
+            <version>3.10.1</version> <!-- {x-version-update;org.apache.maven.plugins:maven-javadoc-plugin;external_dependency} -->
             <configuration>
               <sourceFileExcludes>
                 <sourceFileExclude>module-info.java</sourceFileExclude>
@@ -396,7 +371,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>${maven-javadoc-plugin.version}</version>
+            <version>3.10.1</version> <!-- {x-version-update;org.apache.maven.plugins:maven-javadoc-plugin;external_dependency} -->
             <configuration>
               <sourceFileExcludes>
                 <sourceFileExclude>module-info.java</sourceFileExclude>
@@ -418,7 +393,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>${maven-compiler-plugin.version}</version>
+            <version>3.13.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-compiler-plugin;external_dependency} -->
             <configuration>
               <testRelease>11</testRelease>
               <compilerArgs combine.children="append">
@@ -454,7 +429,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven-surefire-plugin.version}</version>
+            <version>3.5.2</version> <!-- {x-version-update;org.apache.maven.plugins:maven-surefire-plugin;external_dependency} -->
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -199,12 +199,8 @@
             <failOnError>true</failOnError>
             <failOnWarnings>true</failOnWarnings>
             <doclint>all</doclint>
+            <detectJavaApiLink>true</detectJavaApiLink>
 
-            <links combine.children="append">
-              <!-- JDK APIs -->
-              <link>https://docs.oracle.com/javase/8/docs/api/</link>
-            </links>
-            <detectJavaApiLink>false</detectJavaApiLink>
             <excludePackageNames>
               *.impl*
             </excludePackageNames>

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/Proxy.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/Proxy.java
@@ -15,11 +15,29 @@ public interface Proxy {
      * States that the proxy can be in.
      */
     enum ProxyState {
+        /**
+         * 1. No connection to proxy has been made.
+         */
         PN_PROXY_NOT_STARTED,
+        /**
+         * 2. Sent initial CONNECT request to proxy.
+         */
         PN_PROXY_CONNECTING,
+        /**
+         * 3. Proxy has responded with a Proxy-Authorization challenge.
+         */
         PN_PROXY_CHALLENGE,
+        /**
+         * 4. Proxy has responded with a Proxy-Authorization challenge.
+         */
         PN_PROXY_CHALLENGE_RESPONDED,
+        /**
+         * 5. Proxy has responded with a Proxy-Authorization challenge.
+         */
         PN_PROXY_CONNECTED,
+        /**
+         * There has been a failure connecting to proxy.
+         */
         PN_PROXY_FAILED
     }
 

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -249,7 +249,8 @@ public class ProxyImpl implements Proxy, TransportLayer {
                         LOGGER.info("Request is missing content. Waiting for more bytes.");
                         break;
                     }
-                    //Clean up response to prepare for challenge
+
+                    // Clean up response to prepare for challenge
                     proxyResponse.set(null);
 
                     final boolean isSuccess = proxyHandler.validateProxyResponse(connectResponse);

--- a/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImpl.java
@@ -129,26 +129,54 @@ public class ProxyImpl implements Proxy, TransportLayer {
         return this.headers;
     }
 
+    /**
+     * Buffer to read responses from.
+     *
+     * @return Buffer to read responses from.
+     */
     protected ByteBuffer getInputBuffer() {
         return this.inputBuffer;
     }
 
+    /**
+     * Buffer to write responses and requests to.
+     *
+     * @return Buffer to write responses and requests to.
+     */
     protected ByteBuffer getOutputBuffer() {
         return this.outputBuffer;
     }
 
+    /**
+     * Whether settings to connect to a proxy are configured.
+     *
+     * @return true if settings are configured, false otherwise.
+     */
     protected boolean getIsProxyConfigured() {
         return this.isProxyConfigured;
     }
 
+    /**
+     * Gets the handler to respond to challenges from the proxy.
+     *
+     * @return the handler to respond to challenges from the proxy.
+     */
     protected ProxyHandler getProxyHandler() {
         return this.proxyHandler;
     }
 
+    /**
+     * Gets the next transport layer in the chain qpid-proton-j uses.
+     *
+     * @return The next transport layer in the chain qpid-proton-j uses.
+     */
     protected Transport getUnderlyingTransport() {
         return this.underlyingTransport;
     }
 
+    /**
+     * Writes the CONNECT request.
+     */
     protected void writeProxyRequest() {
         outputBuffer.clear();
         final String request = proxyHandler.createProxyRequest(host, headers);
@@ -163,6 +191,11 @@ public class ProxyImpl implements Proxy, TransportLayer {
         outputBuffer.put(request.getBytes());
     }
 
+    /**
+     * Whether handshake is in progress.
+     *
+     * @return True if handshake is in progress.
+     */
     protected boolean getIsHandshakeInProgress() {
         // if handshake is in progress
         // we do not engage the underlying transportInput/transportOutput.
@@ -175,6 +208,11 @@ public class ProxyImpl implements Proxy, TransportLayer {
         return isProxyConfigured && proxyState != ProxyState.PN_PROXY_CONNECTED;
     }
 
+    /**
+     * Gets the current state of the proxy.
+     *
+     * @return State of the proxy.
+     */
     protected ProxyState getProxyState() {
         return this.proxyState;
     }

--- a/src/main/java/com/microsoft/azure/proton/transport/ws/WebSocketHandler.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/ws/WebSocketHandler.java
@@ -14,11 +14,29 @@ public interface WebSocketHandler {
      * States when parsing a frame.
      */
     enum WebSocketMessageType {
+        /**
+         * Unknown frame.
+         */
         WEB_SOCKET_MESSAGE_TYPE_UNKNOWN,
+        /**
+         * Frame received is part of a multi-framed message.
+         */
         WEB_SOCKET_MESSAGE_TYPE_CHUNK,
+        /**
+         * Header frame received is part of a multi-framed message.
+         */
         WEB_SOCKET_MESSAGE_TYPE_HEADER_CHUNK,
+        /**
+         * Frame received is AMQP data.
+         */
         WEB_SOCKET_MESSAGE_TYPE_AMQP,
+        /**
+         * Received a PING from the endpoint.
+         */
         WEB_SOCKET_MESSAGE_TYPE_PING,
+        /**
+         * Receiving has completed because a close message was received.
+         */
         WEB_SOCKET_MESSAGE_TYPE_CLOSE,
     }
 

--- a/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketHandlerImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketHandlerImpl.java
@@ -17,6 +17,9 @@ import java.util.Map;
 public class WebSocketHandlerImpl implements WebSocketHandler {
     private WebSocketUpgrade webSocketUpgrade = null;
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String createUpgradeRequest(
             String hostName,
@@ -29,6 +32,9 @@ public class WebSocketHandlerImpl implements WebSocketHandler {
         return webSocketUpgrade.createUpgradeRequest();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void createPong(ByteBuffer ping, ByteBuffer pong) {
         if ((ping == null) || (pong == null)) {
@@ -51,6 +57,9 @@ public class WebSocketHandlerImpl implements WebSocketHandler {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Boolean validateUpgradeReply(ByteBuffer buffer) {
         Boolean retVal = false;
@@ -72,6 +81,9 @@ public class WebSocketHandlerImpl implements WebSocketHandler {
         return retVal;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void wrapBuffer(ByteBuffer srcBuffer, ByteBuffer dstBuffer) {
         if ((srcBuffer == null) || (dstBuffer == null)) {
@@ -154,6 +166,9 @@ public class WebSocketHandlerImpl implements WebSocketHandler {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public WebsocketTuple unwrapBuffer(ByteBuffer srcBuffer) {
         WebsocketTuple result = new WebsocketTuple(0, WebSocketMessageType.WEB_SOCKET_MESSAGE_TYPE_UNKNOWN);
@@ -220,6 +235,18 @@ public class WebSocketHandlerImpl implements WebSocketHandler {
         return result;
     }
 
+    /**
+     * Creates the initial Connection: upgrade request to use WebSocket.
+     *
+     * @param hostName host name to send the request to
+     * @param webSocketPath path on the request url where WebSocketUpgrade will be sent to
+     * @param webSocketQuery query on the request url where WebSocketUpgrade will be sent to
+     * @param webSocketPort port on the request url where WebSocketUpgrade will be sent to
+     * @param webSocketProtocol value for Sec-WebSocket-Protocol header on the WebSocketUpgrade request
+     * @param additionalHeaders any additional headers to be part of the WebSocketUpgrade request
+     *
+     * @return The upgrade request.
+     */
     protected WebSocketUpgrade createWebSocketUpgrade(
             String hostName,
             String webSocketPath,
@@ -230,6 +257,12 @@ public class WebSocketHandlerImpl implements WebSocketHandler {
         return new WebSocketUpgrade(hostName, webSocketPath, webSocketQuery, webSocketPort, webSocketProtocol, additionalHeaders);
     }
 
+
+    /**
+     * Returns a set of random bytes.
+     *
+     * @return a random set of 4 bytes.
+     */
     protected byte[] createRandomMaskingKey() {
         final byte[] maskingKey = new byte[4];
         Utils.getSecureRandom().nextBytes(maskingKey);

--- a/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketImpl.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketImpl.java
@@ -53,6 +53,9 @@ public class WebSocketImpl implements WebSocket, TransportLayer {
     private String protocol = "";
     private Map<String, String> additionalHeaders = null;
 
+    /**
+     * Whether web sockets are enabled.
+     */
     protected Boolean isWebSocketEnabled;
 
     private WebSocketHandler.WebSocketMessageType lastType;
@@ -200,6 +203,9 @@ public class WebSocketImpl implements WebSocket, TransportLayer {
         return builder.toString();
     }
 
+    /**
+     * Writes the initial upgrade connection request.
+     */
     protected void writeUpgradeRequest() {
         outputBuffer.clear();
 
@@ -210,10 +216,16 @@ public class WebSocketImpl implements WebSocket, TransportLayer {
         outputBuffer.put(request.getBytes());
     }
 
+    /**
+     * Writes the response to a PING request.
+     */
     protected void writePong() {
         webSocketHandler.createPong(pingBuffer, outputBuffer);
     }
 
+    /**
+     * Writes the CLOSE frame.
+     */
     protected void writeClose() {
         outputBuffer.clear();
         pingBuffer.flip();

--- a/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketSniffer.java
+++ b/src/main/java/com/microsoft/azure/proton/transport/ws/impl/WebSocketSniffer.java
@@ -21,6 +21,11 @@ public class WebSocketSniffer extends HandshakeSniffingTransportWrapper<Transpor
         super(webSocket, other);
     }
 
+    /**
+     * Gets the layer in the proton-j transport chain to read web socket frames from.
+     *
+     * @return The layer in the proton-j transport chain to read web socket frames from.
+     */
     protected TransportWrapper getSelectedTransportWrapper() {
         return _selectedTransportWrapper;
     }

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticatorTests.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyAuthenticatorTests.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class ProxyAuthenticatorTests {
@@ -114,7 +114,7 @@ public class ProxyAuthenticatorTests {
         PasswordAuthentication authentication = proxyAuthenticator.getPasswordAuthentication(scheme, PROXY_ADDRESS);
 
         // Assert
-        verifyZeroInteractions(proxySelector);
+        verifyNoInteractions(proxySelector);
 
         Assert.assertNotNull(authentication);
         Assert.assertEquals(configuration.credentials().getUserName(), authentication.getUserName());
@@ -148,7 +148,7 @@ public class ProxyAuthenticatorTests {
         PasswordAuthentication authentication = proxyAuthenticator.getPasswordAuthentication(scheme, PROXY_ADDRESS);
 
         // Assert
-        verifyZeroInteractions(proxySelector);
+        verifyNoInteractions(proxySelector);
 
         Assert.assertNotNull(authentication);
         Assert.assertEquals(configuration.credentials().getUserName(), authentication.getUserName());

--- a/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImplTest.java
+++ b/src/test/java/com/microsoft/azure/proton/transport/proxy/impl/ProxyImplTest.java
@@ -76,6 +76,7 @@ public class ProxyImplTest {
 
     @Captor
     private ArgumentCaptor<Map<String, String>> additionalHeaders;
+    private AutoCloseable closeable;
 
     private void initHeaders() {
         headers.put("header1", "value1");
@@ -85,7 +86,7 @@ public class ProxyImplTest {
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         originalProxy = ProxySelector.getDefault();
 
@@ -118,9 +119,11 @@ public class ProxyImplTest {
     }
 
     @After
-    public void teardown() {
-        Mockito.framework().clearInlineMocks();
+    public void tearDown() throws Exception {
         ProxySelector.setDefault(originalProxy);
+
+        Mockito.framework().clearInlineMocks();
+        closeable.close();
     }
 
     @Test


### PR DESCRIPTION
Migrates to update dependency versions based on scripts in [azure-sdk-for-java](https://github.com/Azure/azure-sdk-for-java/). Fixes issues that came from upgrading:
* Build breaks from deprecated Mockito APIs.
* Javadoc generation issues (that came from upgrading dependencies) 

Adds section in CONTRIBUTING about updating dependencies.
